### PR TITLE
Support multiple JIRA instances

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/ConfigValidator.java
+++ b/src/main/java/com/isroot/stash/plugin/ConfigValidator.java
@@ -1,19 +1,16 @@
 package com.isroot.stash.plugin;
 
-import com.atlassian.applinks.api.CredentialsRequiredException;
-import com.atlassian.sal.api.net.ResponseException;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.setting.RepositorySettingsValidator;
 import com.atlassian.stash.setting.Settings;
 import com.atlassian.stash.setting.SettingsValidationErrors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author sdford
@@ -48,22 +45,10 @@ public class ConfigValidator implements RepositorySettingsValidator
         String jqlMatcher = settings.getString("issueJqlMatcher");
         if(!isNullOrEmpty(jqlMatcher))
         {
-            try
+            List<String> jqlErrors = jiraService.checkJqlQuery(jqlMatcher);
+            for (String err : jqlErrors)
             {
-                if(!jiraService.isJqlQueryValid(jqlMatcher))
-                {
-                    errors.addFieldError("issueJqlMatcher", "The JQL query syntax is invalid.");
-                }
-            }
-            catch(ResponseException ex)
-            {
-                log.error("unexpected exception while trying to validate jql query", ex);
-                errors.addFieldError("issueJqlMatcher", "Unable to validate JQL query with JIRA because there was an unexpected exception. Please see Stash logs.");
-            }
-            catch(CredentialsRequiredException ex)
-            {
-                log.error("authentication error while trying to validate jql query", ex);
-                errors.addFieldError("issueJqlMatcher", "Unable to validate JQL query with JIRA. Authentication failure when communicating with JIRA.");
+                errors.addFieldError("issueJqlMatcher", err);
             }
         }
     }

--- a/src/main/java/com/isroot/stash/plugin/ErrorParsingReturningResponseHandler.java
+++ b/src/main/java/com/isroot/stash/plugin/ErrorParsingReturningResponseHandler.java
@@ -1,0 +1,78 @@
+package com.isroot.stash.plugin;
+
+import com.atlassian.sal.api.net.Response;
+import com.atlassian.sal.api.net.ResponseException;
+import com.atlassian.sal.api.net.ResponseStatusException;
+import com.atlassian.sal.api.net.ReturningResponseHandler;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+
+/**
+ *
+ * @author Bradley Baetz
+ */
+public class ErrorParsingReturningResponseHandler implements ReturningResponseHandler<Response, String>
+{
+
+    @Override
+    public String handle(Response response) throws ResponseException
+    {
+        // Need to retrieve the body here, otherwise its not read
+        // at all due to the exception being thrown
+
+        // Also, use the stream method because .getResponseBodyAsString()
+        // logs an error to the logs each time
+        // The warning is because the resposne body might be too large
+        // to buffer in memory, but in our case that's OK (small responses,
+        // made to a trusted server)
+        String body;
+        try
+        {
+            body = IOUtils.toString(response.getResponseBodyAsStream());
+        }
+        catch (IOException ex)
+        {
+            throw new ResponseException(ex);
+        }
+
+        if (response.isSuccessful())
+        {
+            return body;
+        }
+
+        if (response.getStatusCode() == 400)
+        {
+            JsonArray errorMessages = null;
+            try
+            {
+                JsonObject jsonResponse = new JsonParser().parse(body).getAsJsonObject();
+                errorMessages = jsonResponse.getAsJsonArray("errorMessages");
+            }
+            catch (IllegalStateException ex)
+            {
+                // JSON parse error - fall back to having no errors
+            }
+
+            if (errorMessages != null && !Iterables.isEmpty(errorMessages))
+            {
+                List<String> errors = Lists.newArrayList();
+
+                // Record the actual error
+                for (JsonElement err : errorMessages)
+                {
+                    errors.add(err.getAsString());
+                }
+                throw new JiraExecutionException("Error response received", errors);
+            }
+        }
+
+        throw new ResponseStatusException("Unexpected response received. Status code: " + response.getStatusCode(), response);
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/IssueKey.java
+++ b/src/main/java/com/isroot/stash/plugin/IssueKey.java
@@ -1,8 +1,7 @@
 package com.isroot.stash.plugin;
 
-import com.google.common.collect.Lists;
-
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,9 +14,10 @@ public class IssueKey
      * Parse any issue keys (i.e., strings that match the standard issue key format) found within the given input.
      *
      * @param input The input string to be parsed for issue keys.
+     * @return The issue keys found
      */
-    static public List<IssueKey> parseIssueKeys (String input) {
-        List<IssueKey> issueKeys = Lists.newArrayList();
+    static public Set<IssueKey> parseIssueKeys (String input) {
+        Set<IssueKey> issueKeys = new HashSet<IssueKey>();
         Matcher matcher = ISSUE_PATTERN.matcher(input);
         while (matcher.find())
         {

--- a/src/main/java/com/isroot/stash/plugin/JiraExecutionException.java
+++ b/src/main/java/com/isroot/stash/plugin/JiraExecutionException.java
@@ -1,0 +1,34 @@
+package com.isroot.stash.plugin;
+
+import com.atlassian.sal.api.net.ResponseException;
+import com.google.common.base.Joiner;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/** 
+ * This class exists because the standard ResponseStatus class doesn't
+ * allow access to the error body (it returns null, because the stream is
+ * not parsed when the exception is thrown)
+ */
+public class JiraExecutionException extends ResponseException
+{
+    private final List<String> errors;
+    
+    public JiraExecutionException(@Nonnull String message, @Nonnull List<String> errors)
+    {
+        super(message);
+        this.errors = errors;
+    }
+    
+    @Nonnull
+    public List<String> getJiraErrors()
+    {
+        return errors;
+    }
+    
+    @Override
+    public String getMessage()
+    {
+        return Joiner.on(", ").join(errors);
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/JiraLookupsException.java
+++ b/src/main/java/com/isroot/stash/plugin/JiraLookupsException.java
@@ -1,0 +1,75 @@
+package com.isroot.stash.plugin;
+
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.CredentialsRequiredException;
+import com.atlassian.sal.api.net.ResponseException;
+import com.atlassian.sal.api.net.ResponseStatusException;
+import com.google.common.base.Joiner;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+public class JiraLookupsException extends Exception
+{
+    private final Map<ApplicationLink, Exception> errors;
+
+    public JiraLookupsException(@Nonnull Map<ApplicationLink, Exception> errors) {
+        checkNotNull(errors);
+        checkState(!errors.isEmpty(), "No errors provided");
+        
+        this.errors = errors;
+    }
+    
+    @Nonnull
+    public Map<ApplicationLink, Exception> getErrors() {
+        return errors;
+    }
+    
+    @Nonnull
+    public List<String> getPrintableErrors() {
+        List<String> ret = new ArrayList<String>();
+        
+        for (Map.Entry<ApplicationLink, Exception> entry : errors.entrySet())
+        {
+            String errorStr;
+            
+            Exception ex = entry.getValue();
+            
+            if (ex instanceof CredentialsRequiredException)
+            {
+                CredentialsRequiredException credentialsRequiredException = (CredentialsRequiredException)ex;
+                errorStr = "Could not authenticate. Visit " + credentialsRequiredException.getAuthorisationURI().toASCIIString() + " to link your Stash account to your JIRA account";
+            }
+            else if (ex instanceof ResponseStatusException)
+            {
+                ResponseStatusException responseStatusException = (ResponseStatusException)ex;
+                errorStr = responseStatusException.getResponse().getStatusText();
+            }
+            else if (ex instanceof ResponseException)
+            {
+                ResponseException responseException = (ResponseException)ex;
+                if (responseException.getCause() != null) {
+                    errorStr = responseException.getCause().getMessage();
+                } else {
+                    errorStr = responseException.getMessage();
+                }
+            }
+            else
+            {
+                errorStr = "Internal error: " + ex.getMessage() + ". Check server logs for details.";
+            }
+            
+            ret.add(entry.getKey().getName() + ": " + errorStr);
+        }
+        
+        return ret;
+    }
+    
+    @Override
+    public String getMessage() {
+        return "JIRA lookup errors: " + Joiner.on(", ").join(getPrintableErrors());
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/JiraService.java
+++ b/src/main/java/com/isroot/stash/plugin/JiraService.java
@@ -1,7 +1,7 @@
 package com.isroot.stash.plugin;
 
-import com.atlassian.applinks.api.CredentialsRequiredException;
-import com.atlassian.sal.api.net.ResponseException;
+import java.util.List;
+import javax.annotation.Nonnull;
 
 /**
  * Service object to interact with JIRA.
@@ -12,8 +12,8 @@ import com.atlassian.sal.api.net.ResponseException;
 public interface JiraService
 {
     public boolean doesJiraApplicationLinkExist();
-    public boolean doesIssueMatchJqlQuery(String jqlQuery, IssueKey issueKey) throws CredentialsRequiredException, ResponseException;
-    public boolean doesIssueExist(IssueKey issueKey) throws CredentialsRequiredException, ResponseException;
-    public boolean doesProjectExist(String projectKey) throws CredentialsRequiredException, ResponseException;
-    public boolean isJqlQueryValid(String jqlQuery) throws CredentialsRequiredException, ResponseException;
+    public boolean doesIssueMatchJqlQuery(@Nonnull String jqlQuery, @Nonnull IssueKey issueKey) throws JiraLookupsException;
+    public boolean doesIssueExist(@Nonnull IssueKey issueKey) throws JiraLookupsException;
+    public boolean doesProjectExist(@Nonnull String projectKey) throws JiraLookupsException;
+    public List<String> checkJqlQuery(@Nonnull String jqlQuery);
 }

--- a/src/main/java/com/isroot/stash/plugin/JiraServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/JiraServiceImpl.java
@@ -3,25 +3,26 @@ package com.isroot.stash.plugin;
 import com.atlassian.applinks.api.ApplicationLink;
 import com.atlassian.applinks.api.ApplicationLinkRequest;
 import com.atlassian.applinks.api.ApplicationLinkRequestFactory;
-import com.atlassian.applinks.api.ApplicationLinkResponseHandler;
 import com.atlassian.applinks.api.ApplicationLinkService;
 import com.atlassian.applinks.api.CredentialsRequiredException;
 import com.atlassian.applinks.api.application.jira.JiraApplicationType;
 import com.atlassian.sal.api.net.Request;
-import com.atlassian.sal.api.net.Response;
 import com.atlassian.sal.api.net.ResponseException;
 import com.atlassian.sal.api.net.ResponseStatusException;
+import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Sean Ford
@@ -38,16 +39,16 @@ public class JiraServiceImpl implements JiraService
         this.applicationLinkService = applicationLinkService;
     }
 
-    private ApplicationLink getJiraApplicationLink()
+    private Iterable<ApplicationLink> getJiraApplicationLinks()
     {
-        ApplicationLink applicationLink = applicationLinkService.getPrimaryApplicationLink(JiraApplicationType.class);
+        Iterable<ApplicationLink> applicationLinks = applicationLinkService.getApplicationLinks(JiraApplicationType.class);
 
-        if (applicationLink == null)
+        if (applicationLinks == null || Iterables.isEmpty(applicationLinks))
         {
-            throw new IllegalStateException("Primary JIRA application link does not exist!");
+            throw new IllegalStateException("JIRA application link does not exist!");
         }
 
-        return applicationLink;
+        return applicationLinks;
     }
 
     @Override
@@ -57,61 +58,113 @@ public class JiraServiceImpl implements JiraService
     }
 
     @Override
-    public boolean doesIssueExist(IssueKey issueKey) throws CredentialsRequiredException, ResponseException
+    public boolean doesIssueExist(@Nonnull IssueKey issueKey) throws JiraLookupsException
     {
         checkNotNull(issueKey, "issueKey is null");
 
-
-        final ApplicationLinkRequestFactory fac = getJiraApplicationLink().createAuthenticatedRequestFactory();
-
-        ApplicationLinkRequest req = fac.createRequest(Request.MethodType.GET, "/rest/api/2/issue/"+issueKey.getFullyQualifiedIssueKey());
-
-        return req.execute(new ApplicationLinkResponseHandler<Boolean>()
+        Map<ApplicationLink, Exception> errors = new HashMap<ApplicationLink, Exception>();
+        
+        for (final ApplicationLink link : getJiraApplicationLinks())
         {
-            @Override
-            public Boolean credentialsRequired(Response response) throws ResponseException
+            try
             {
-                throw new ResponseException(new CredentialsRequiredException(fac, "Token is invalid"));
-            }
+                final ApplicationLinkRequestFactory fac = link.createAuthenticatedRequestFactory();
 
-            @Override
-            public Boolean handle(Response response) throws ResponseException
-            {
-                return response.isSuccessful();
+                ApplicationLinkRequest req = fac.createRequest(Request.MethodType.GET, "/rest/api/2/issue/"+issueKey.getFullyQualifiedIssueKey()+"?fields=summary");
+                
+                req.executeAndReturn(new ErrorParsingReturningResponseHandler());
+                
+                // No error, so must exist
+                return true;
             }
-        });
+            catch (ResponseStatusException e)
+            {
+                if (e.getResponse().getStatusCode() == 404)
+                {
+                    /* Project is unknown */
+                    continue;
+                }
+
+                errors.put(link, e);
+            }
+            catch (CredentialsRequiredException e)
+            {
+                errors.put(link, e);
+            }
+            catch (ResponseException e)
+            {
+                errors.put(link, e);
+            }
+            catch (Exception e)
+            {
+                log.error("Unknown error validating issue", e);
+                errors.put(link, e);
+            }
+        }
+        
+        if (!errors.isEmpty()) {
+            throw new JiraLookupsException(errors);
+        }
+        
+        return false;
     }
 
     @Override
-    public boolean doesProjectExist(String projectKey) throws CredentialsRequiredException, ResponseException
+    public boolean doesProjectExist(@Nonnull String projectKey) throws JiraLookupsException
     {
         checkNotNull(projectKey, "projectKey is null");
-
-        ApplicationLinkRequest req = getJiraApplicationLink().createAuthenticatedRequestFactory().createRequest(Request.MethodType.GET, "/rest/api/2/project/" + projectKey);
-
-        try
+        
+        Map<ApplicationLink, Exception> errors = new HashMap<ApplicationLink, Exception>();
+        
+        for (final ApplicationLink link : getJiraApplicationLinks())
         {
-            String jsonResponse = req.execute();
-            JsonObject response = new JsonParser().parse(jsonResponse).getAsJsonObject();
-            return (projectKey.equals(response.get("key").getAsString()));
+            try
+            {
+                ApplicationLinkRequest req = link.createAuthenticatedRequestFactory().createRequest(Request.MethodType.GET, "/rest/api/2/project/" + projectKey);
+                String jsonResponse = req.executeAndReturn(new ErrorParsingReturningResponseHandler());
+                JsonObject response = new JsonParser().parse(jsonResponse).getAsJsonObject();
+                
+                if (projectKey.equals(response.get("key").getAsString())) {
+                    return true;
+                }
+            }
+            catch (ResponseStatusException e)
+            {
+                if (e.getResponse().getStatusCode() == 404)
+                {
+                    /* Project is unknown */
+                    continue;
+                }
+
+                errors.put(link, e);
+            }
+            catch (CredentialsRequiredException e)
+            {
+                errors.put(link, e);
+            }
+            catch (ResponseException e)
+            {
+                // Don't log the full stack trace - connection timeouts/etc
+                // are clear from the error message
+                errors.put(link, e);
+            }
+            catch (Exception e)
+            {
+                log.error("Unknown error validating project", e);
+                errors.put(link, e);
+            }
         }
-        catch (ResponseStatusException e)
+        
+        if (!errors.isEmpty())
         {
-            if (e.getResponse().getStatusCode() == 404)
-            {
-                /* Project is unknown */
-                return false;
-            }
-            else
-            {
-                throw new ResponseException("Request failed", e);
-            }
+            throw new JiraLookupsException(errors);
         }
+        
+        return false;
     }
 
     @Override
-    public boolean doesIssueMatchJqlQuery(String jqlQuery, IssueKey issueKey) throws CredentialsRequiredException,
-            ResponseException
+    public boolean doesIssueMatchJqlQuery(@Nonnull String jqlQuery, @Nonnull IssueKey issueKey) throws JiraLookupsException
     {
         checkNotNull(jqlQuery, "jqlQuery is null");
         checkNotNull(issueKey, "issueKey is null");
@@ -121,45 +174,124 @@ public class JiraServiceImpl implements JiraService
         String jqlQueryWithIssueExpression = String.format("issueKey=%s and (%s)", issueKey.getFullyQualifiedIssueKey(),
                 jqlQuery);
 
-        String jsonResponse = executeJqlQuery(jqlQueryWithIssueExpression);
+        Map<ApplicationLink, Exception> errors = new HashMap<ApplicationLink, Exception>();
+        List<ApplicationLink> notFound = new ArrayList<ApplicationLink>();
+        
+        for (final ApplicationLink link : getJiraApplicationLinks())
+        {
+            try
+            {
+                String jsonResponse = executeJqlQuery(link, jqlQueryWithIssueExpression);
 
-        JsonObject response = new JsonParser().parse(jsonResponse).getAsJsonObject();
-        JsonArray issues = response.get("issues").getAsJsonArray();
+                JsonObject response = new JsonParser().parse(jsonResponse).getAsJsonObject();
+                JsonArray issues = response.get("issues").getAsJsonArray();
 
-        return issues.size() == 1;
+                if (issues.size() > 0)
+                {
+                    return true;
+                }
+                else
+                {
+                    notFound.add(link);
+                }
+            }
+            catch (JiraExecutionException e)
+            {
+                // Older versions of JIRA (<6.0.3) don't support the validateQuery param, so they
+                // throw an error if the JIRA doesn't exist.
+                // If Stash is linked to multiple JIRA versions, one new and one old
+                // then we get an error from the old JIRA and no result from the new one.
+                // This leads to reporting the error to the user, but not the no result,
+                // which is confusing.
+                // To manage that, swallow the errors.
+                // The parsing doesn't have to be too flexible, because newer versions will support
+                // this parameter...
+                List<String> jiraErrors = e.getJiraErrors();
+                if (jiraErrors.size() == 1 && jiraErrors.get(0).contains(issueKey.getFullyQualifiedIssueKey()))
+                {
+                    notFound.add(link);
+                }
+                else
+                {
+                    errors.put(link, e);
+                }
+            }
+            catch (CredentialsRequiredException e)
+            {
+                errors.put(link, e);
+            }
+            catch (ResponseException e)
+            {
+                errors.put(link, e);
+            }
+            catch (Exception e)
+            {
+                log.error("Unknown error running JQL query", e);
+                errors.put(link, e);
+            }
+        }
+
+        if (!errors.isEmpty())
+        {
+            // Add all the JIRAs where the response wasn't matched,
+            // so that the user can see the problem for all the linked JIRAs
+            for (ApplicationLink link : notFound)
+            {
+                errors.put(link, new ResponseException(issueKey.getFullyQualifiedIssueKey() + ": JIRA issue does not match JQL query: " + jqlQuery));
+            }
+            throw new JiraLookupsException(errors);
+        }
+        
+        return false;
     }
 
     @Override
-    public boolean isJqlQueryValid(String jqlQuery) throws CredentialsRequiredException, ResponseException
+    public List<String> checkJqlQuery(@Nonnull String jqlQuery)
     {
-        try
+        checkNotNull(jqlQuery, "jqlQuery is null");
+        
+        // Note that we still need to iterate over all of the application links here,
+        // because a query using a custom field may not be valid on all instances
+        Map<ApplicationLink, Exception> errors = new HashMap<ApplicationLink, Exception>();
+        
+        for (final ApplicationLink link : getJiraApplicationLinks())
         {
-            // This will throw an exception if the jql query is invalid.
-            executeJqlQuery(jqlQuery);
-            return true;
-        }
-        catch(ResponseStatusException e)
-        {
-            // if the jql query is invalid, a 400 error is returned
-            if(e.getResponse().getStatusCode() == 400)
+            try
             {
-                return false;
+                // This will throw an exception if the jql query is invalid.
+                executeJqlQuery(link, jqlQuery);
+                return ImmutableList.<String>of();
             }
-            else
+            catch (CredentialsRequiredException e)
             {
-                // Not a 400 response... just re-throw it to avoid hiding potential problems
-                throw e;
+                errors.put(link, e);
             }
-
+            catch (ResponseException e)
+            {
+                errors.put(link, e);
+            }
+            catch (Exception e)
+            {
+                log.error("Unknown error validating JQL query", e);
+                errors.put(link, e);
+            }
         }
+        
+        if (!errors.isEmpty()) {
+            // Eww....
+            JiraLookupsException ex = new JiraLookupsException(errors);
+            return ex.getPrintableErrors();
+        }
+        
+        return ImmutableList.<String>of();
     }
 
-    private String executeJqlQuery(String jqlQuery) throws CredentialsRequiredException, ResponseException
+    private String executeJqlQuery(ApplicationLink link, String jqlQuery) throws CredentialsRequiredException, ResponseException
     {
         checkNotNull(jqlQuery, "jqlQuery is null");
 
-        ApplicationLinkRequest req = getJiraApplicationLink().createAuthenticatedRequestFactory()
-                .createRequest(Request.MethodType.POST, "/rest/api/2/search");
+        ApplicationLinkRequest req = link.createAuthenticatedRequestFactory()
+                .createRequest(Request.MethodType.POST, "/rest/api/2/search?fields=summary&validateQuery=false");
         req.setHeader("Content-Type", "application/json");
 
         log.debug("using jql: {}", jqlQuery);
@@ -168,7 +300,7 @@ public class JiraServiceImpl implements JiraService
         request.put("jql", jqlQuery);
         req.setEntity(new Gson().toJson(request));
 
-        String response = req.execute();
+        String response = req.executeAndReturn(new ErrorParsingReturningResponseHandler());
 
         log.debug("json response: {}", response);
 

--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -151,7 +152,7 @@ public class YaccServiceImpl implements YaccService
         return errors;
     }
 
-    private List<IssueKey> extractJiraIssuesFromCommitMessage(Settings settings, YaccChangeset changeset)
+    private Set<IssueKey> extractJiraIssuesFromCommitMessage(Settings settings, YaccChangeset changeset)
     {
         String message = changeset.getMessage();
 
@@ -168,7 +169,7 @@ public class YaccServiceImpl implements YaccService
             }
         }
 
-        final List<IssueKey> issueKeys = IssueKey.parseIssueKeys(message);
+        final Set<IssueKey> issueKeys = IssueKey.parseIssueKeys(message);
         log.debug("found jira issues {} from commit message: {}", issueKeys, message);
 
         return issueKeys;
@@ -189,12 +190,12 @@ public class YaccServiceImpl implements YaccService
             return errors;
         }
 
-        final List<IssueKey> issues;
-        final List<IssueKey> extractedKeys = extractJiraIssuesFromCommitMessage(settings, changeset);
+        final Set<IssueKey> issues;
+        final Set<IssueKey> extractedKeys = extractJiraIssuesFromCommitMessage(settings, changeset);
         if (settings.getBoolean("ignoreUnknownIssueProjectKeys", false))
         {
             /* Remove issues that contain non-existent project keys */
-            issues = Lists.newArrayList();
+            issues = new HashSet<IssueKey>();
             for (IssueKey issueKey : extractedKeys) {
                 try
                 {

--- a/src/test/java/ut/com/isroot/stash/plugin/IssueKeyTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/IssueKeyTest.java
@@ -1,31 +1,26 @@
 package ut.com.isroot.stash.plugin;
 
-import com.google.common.collect.Lists;
 import com.isroot.stash.plugin.InvalidIssueKeyException;
 import com.isroot.stash.plugin.IssueKey;
+
+import java.util.Set;
+import static org.fest.assertions.api.Assertions.assertThat;
 import org.junit.Test;
-
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class IssueKeyTest
 {
     @Test
     public void testParseIssueKeys() {
-        final List<IssueKey> issueKeys = IssueKey.parseIssueKeys("Issue: ABC-123, CBA-321, UNDER_SCORE-123;");
-        assertEquals(issueKeys, Lists.newArrayList(new IssueKey("ABC", "123"),
-                new IssueKey("CBA", "321"), new IssueKey("UNDER_SCORE", "123")));
+        final Set<IssueKey> issueKeys = IssueKey.parseIssueKeys("Issue: ABC-123, CBA-321, UNDER_SCORE-123;");
+        assertThat(issueKeys).containsOnly(new IssueKey("ABC", "123"),
+                new IssueKey("CBA", "321"), new IssueKey("UNDER_SCORE", "123"));
     }
 
     @Test
     public void testParseValidIssueKey() throws InvalidIssueKeyException {
         final IssueKey parsed = new IssueKey("ABC-123");
-        assertEquals("ABC", parsed.getProjectKey());
-        assertEquals("123", parsed.getIssueId());
+        assertThat(parsed.getProjectKey()).isEqualTo("ABC");
+        assertThat(parsed.getIssueId()).isEqualTo("123");
     }
 
     @Test(expected = InvalidIssueKeyException.class)
@@ -35,21 +30,21 @@ public class IssueKeyTest
 
     @Test
     public void testGetFullyQualifiedIssueKey() throws InvalidIssueKeyException {
-        assertEquals("ABC-123", new IssueKey("ABC", "123").getFullyQualifiedIssueKey());
-        assertEquals("ABC-123", new IssueKey("ABC-123").getFullyQualifiedIssueKey());
+        assertThat(new IssueKey("ABC", "123").getFullyQualifiedIssueKey()).isEqualTo("ABC-123");
+        assertThat(new IssueKey("ABC-123").getFullyQualifiedIssueKey()).isEqualTo("ABC-123");
     }
 
     @Test
     public void testEquality() throws InvalidIssueKeyException {
-        assertEquals(new IssueKey("ABC-123"), new IssueKey("ABC-123"));
-        assertEquals(new IssueKey("ABC-123").hashCode(), new IssueKey("ABC-123").hashCode());
+        assertThat(new IssueKey("ABC-123")).isEqualTo(new IssueKey("ABC-123"));
+        assertThat(new IssueKey("ABC-123").hashCode()).isEqualTo(new IssueKey("ABC-123").hashCode());
 
         /* Differs by issueId */
-        assertThat(new IssueKey("ABC-123"), is(not(new IssueKey("ABC-321"))));
-        assertThat(new IssueKey("ABC-123").hashCode(), is(not(new IssueKey("ABC-321").hashCode())));
+        assertThat(new IssueKey("ABC-123")).isNotEqualTo(new IssueKey("ABC-321"));
+        assertThat(new IssueKey("ABC-123").hashCode()).isNotEqualTo(new IssueKey("ABC-321").hashCode());
 
         /* Differs by projectKey */
-        assertThat(new IssueKey("ABC-123"), is(not(new IssueKey("CBA-123"))));
-        assertThat(new IssueKey("ABC-123").hashCode(), is(not(new IssueKey("CBA-123").hashCode())));
+        assertThat(new IssueKey("ABC-123")).isNotEqualTo(new IssueKey("CBA-321"));
+        assertThat(new IssueKey("ABC-123").hashCode()).isNotEqualTo(new IssueKey("CBA-321").hashCode());
     }
 }

--- a/src/test/java/ut/com/isroot/stash/plugin/JiraLookupsExceptionTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/JiraLookupsExceptionTest.java
@@ -1,0 +1,100 @@
+package ut.com.isroot.stash.plugin;
+
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.CredentialsRequiredException;
+import com.atlassian.sal.api.net.ResponseException;
+import com.atlassian.sal.api.net.ResponseStatusException;
+import com.google.common.collect.ImmutableMap;
+import com.isroot.stash.plugin.JiraLookupsException;
+import java.net.URI;
+import java.util.List;
+import static org.fest.assertions.api.Assertions.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+public class JiraLookupsExceptionTest
+{
+    @Before
+    public void setup()
+    {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel","DEBUG");
+
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void test_messageFormat_credentialsRequired() throws Exception
+    {
+        CredentialsRequiredException credentialsRequiredException = mock(CredentialsRequiredException.class);
+        when(credentialsRequiredException.getAuthorisationURI()).thenReturn(new URI("http://localhost:2990/jira"));
+        
+        JiraLookupsException ex = createJiraLookupsException("JIRA", credentialsRequiredException);
+        
+        List<String> errors = ex.getPrintableErrors();
+        assertThat(errors).containsOnly("JIRA: Could not authenticate. Visit http://localhost:2990/jira to link your Stash account to your JIRA account");
+    }
+    
+    @Test
+    public void test_messageFormat_responseStatus() throws Exception
+    {
+        ResponseStatusException responseStatusException = mock(ResponseStatusException.class, RETURNS_DEEP_STUBS);
+        when(responseStatusException.getResponse().getStatusText()).thenReturn("Response Status Error");
+        
+        JiraLookupsException ex = createJiraLookupsException("JIRA", responseStatusException);
+        
+        List<String> errors = ex.getPrintableErrors();
+        assertThat(errors).containsOnly("JIRA: Response Status Error");
+    }
+    
+    @Test
+    public void test_messageFormat_response()
+    {
+        ResponseException responseException = mock(ResponseException.class);
+        when(responseException.getCause()).thenReturn(null);
+        when(responseException.getMessage()).thenReturn("Response Error");
+        
+        JiraLookupsException ex = createJiraLookupsException("JIRA", responseException);
+        
+        List<String> errors = ex.getPrintableErrors();
+        assertThat(errors).containsOnly("JIRA: Response Error");
+    }
+    
+    @Test
+    public void test_messageFormat_responseCause()
+    {
+        ResponseException responseException = mock(ResponseException.class, RETURNS_DEEP_STUBS);
+        when(responseException.getCause().getMessage()).thenReturn("Response Cause Error");
+        
+        JiraLookupsException ex = createJiraLookupsException("JIRA", responseException);
+        
+        List<String> errors = ex.getPrintableErrors();
+        assertThat(errors).containsOnly("JIRA: Response Cause Error");
+    }
+    
+    @Test
+    public void test_messageFormat_otherException()
+    {
+        Exception e = mock(Exception.class);
+        when(e.getMessage()).thenReturn("Exception message");
+        
+        JiraLookupsException ex = createJiraLookupsException("JIRA", e);
+        
+        List<String> errors = ex.getPrintableErrors();
+        assertThat(errors).containsOnly("JIRA: Internal error: Exception message. Check server logs for details.");
+    }
+    
+    private ApplicationLink mockApplicationLink(String name)
+    {
+        ApplicationLink link = mock(ApplicationLink.class);
+        when(link.getName()).thenReturn(name);
+        
+        return link;
+    }
+    
+    private JiraLookupsException createJiraLookupsException(String link, Exception error)
+    {
+        return new JiraLookupsException(ImmutableMap.of(mockApplicationLink(link), error));
+    }
+}

--- a/src/test/java/ut/com/isroot/stash/plugin/JiraServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/JiraServiceImplTest.java
@@ -2,25 +2,34 @@ package ut.com.isroot.stash.plugin;
 
 import com.atlassian.applinks.api.ApplicationLink;
 import com.atlassian.applinks.api.ApplicationLinkRequest;
+import com.atlassian.applinks.api.ApplicationLinkRequestFactory;
 import com.atlassian.applinks.api.ApplicationLinkService;
 import com.atlassian.applinks.api.application.jira.JiraApplicationType;
 import com.atlassian.sal.api.net.Request;
+import com.atlassian.sal.api.net.Response;
+import com.atlassian.sal.api.net.ResponseException;
 import com.atlassian.sal.api.net.ResponseStatusException;
+import com.atlassian.sal.api.net.ReturningResponseHandler;
+import com.google.common.collect.ImmutableList;
 import com.isroot.stash.plugin.IssueKey;
+import com.isroot.stash.plugin.JiraExecutionException;
+import com.isroot.stash.plugin.JiraLookupsException;
 import com.isroot.stash.plugin.JiraService;
 import com.isroot.stash.plugin.JiraServiceImpl;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import static org.fest.assertions.api.Assertions.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import static org.mockito.Mockito.*;
 import org.mockito.MockitoAnnotations;
-
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Sean Ford
@@ -29,9 +38,6 @@ import static org.mockito.Mockito.when;
 public class JiraServiceImplTest
 {
     @Mock
-    private ApplicationLinkRequest applicationLinkRequest;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ApplicationLinkService applicationLinkService;
 
     private JiraService jiraService;
@@ -55,7 +61,7 @@ public class JiraServiceImplTest
     @Test
     public void testDoesJiraApplicationLinkExist_returnsTrueIfLinkExists() throws Exception
     {
-        when(applicationLinkService.getPrimaryApplicationLink(JiraApplicationType.class)).thenReturn(mock(ApplicationLink.class));
+        setupApplicationLink();
 
         assertThat(jiraService.doesJiraApplicationLinkExist()).isTrue();
     }
@@ -63,7 +69,9 @@ public class JiraServiceImplTest
     @Test
     public void testDoesIssueMatchJqlQuery_finalJqlQueryContainsBothIssueKeyAndUserQuery() throws Exception
     {
-        jiraService = setupJqlTest("{\"issues\": []}");
+        ApplicationLink link = setupApplicationLink();
+        
+        ApplicationLinkRequest applicationLinkRequest = setupJqlTest(link, "{\"issues\": [{}]}");
 
         jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123"));
 
@@ -73,81 +81,374 @@ public class JiraServiceImplTest
     @Test
     public void testDoesIssueMatchJqlQuery_httpRequestDetails() throws Exception
     {
-        jiraService = setupJqlTest("{\"issues\": []}");
+        ApplicationLink link = setupApplicationLink();
+        
+        ApplicationLinkRequest applicationLinkRequest = setupJqlTest(link, "{\"issues\": [{}]}");
 
         jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123"));
+        
+        setApplicationLinks(link);
 
-        verify(applicationLinkService.getPrimaryApplicationLink(JiraApplicationType.class).createAuthenticatedRequestFactory())
-                .createRequest(Request.MethodType.POST, "/rest/api/2/search");
+        verify(link.createAuthenticatedRequestFactory())
+                .createRequest(Request.MethodType.POST, "/rest/api/2/search?fields=summary&validateQuery=false");
         verify(applicationLinkRequest).setHeader("Content-Type", "application/json");
     }
 
     @Test
     public void testDoesIssueMatchJqlQuery_returnsFalseIfNoIssuesMatchJql() throws Exception
     {
-        jiraService = setupJqlTest("{\"issues\": []}");
+        ApplicationLink link = setupApplicationLink();
+        
+        IssueKey issueKey = new IssueKey("TEST", "123");
+        
+        setupJqlTest(link, "{\"issues\": []}");
+        setupIssueTest(link, issueKey, true);
 
-        assertThat(jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123")))
+        assertThat(jiraService.doesIssueMatchJqlQuery("project = TEST", issueKey))
                 .isFalse();
     }
 
     @Test
     public void testDoesIssueMatchJqlQuery_returnsTrueIfIssuesMatchJql() throws Exception
     {
-        jiraService = setupJqlTest("{\"issues\": [{}]}");
+        ApplicationLink link = setupApplicationLink();
+        
+        setupJqlTest(link, "{\"issues\": [{}]}");
 
         assertThat(jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123")))
                 .isTrue();
     }
-
+    
     @Test
-    public void testIsJqlIssueValid_returnsTrueIfValid() throws Exception
+    public void testDoesIssueMatchJqlQuery_multipleAppLinks_fallthroughAfterNoMatch() throws Exception
     {
-        assertThat(jiraService.isJqlQueryValid("assignee is not empty")).isTrue();
+        IssueKey issueKey = new IssueKey("TEST", "123");
+        
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        setupJqlTest(link1, "{\"issues\": []}");
+        setupIssueTest(link1, issueKey, false);
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        setupJqlTest(link2, "{\"issues\": [{}]}");
+        
+        setApplicationLinks(link1, link2);
+        
+        assertThat(jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123")))
+                .isTrue();
     }
-
+    
     @Test
-    public void testIsJqlQueryValid_returnsFalseIfNotValid() throws Exception
+    public void testDoesIssueMatchJqlQuery_multipleAppLinks_fallthroughAfterError() throws Exception
     {
-        jiraService = setupJqlTest(null);
-
-        ResponseStatusException ex = mock(ResponseStatusException.class, RETURNS_DEEP_STUBS);
-        when(ex.getResponse().getStatusCode()).thenReturn(400);
-        when(applicationLinkRequest.execute()).thenThrow(ex);
-
-        assertThat(jiraService.isJqlQueryValid("invalid jql query@#%$")).isFalse();
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        setupJqlTest(link1, mock(ResponseException.class));
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        setupJqlTest(link2, "{\"issues\": [{}]}");
+        
+        setApplicationLinks(link1, link2);
+        
+        assertThat(jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123")))
+                .isTrue();
     }
-
+    
     @Test
-    public void testIsJqlQueryValid_unknownExceptionsAreRethrown() throws Exception
+    public void testDoesIssueMatchJqlQuery_multipleAppLinks_stopAfterSuccess() throws Exception
     {
-        jiraService = setupJqlTest(null);
-
-        ResponseStatusException ex = mock(ResponseStatusException.class, RETURNS_DEEP_STUBS);
-        when(ex.getResponse().getStatusCode()).thenReturn(500);
-        when(applicationLinkRequest.execute()).thenThrow(ex);
-
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        setupJqlTest(link1, "{\"issues\": [{}]}");
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        
+        setApplicationLinks(link1, link2);
+        
+        assertThat(jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123")))
+                .isTrue();
+        verifyNoMoreInteractions(link2);
+    }
+    
+    @Test
+    public void testDoesIssueMatchJqlQuery_multipleAppLinks_allErrorsAreCaptured() throws Exception
+    {
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        ResponseException ex1 = mock(ResponseException.class);
+        setupJqlTest(link1, ex1);
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        ResponseException ex2 = mock(ResponseException.class);
+        setupJqlTest(link2, ex2);
+        
+        setApplicationLinks(link1, link2);
+        
         try
         {
-            jiraService.isJqlQueryValid("jql query");
-            Assert.fail();
+            jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123"));
+            Assert.fail("Exception not thrown");
         }
-        catch(ResponseStatusException expected)
+        catch (JiraLookupsException expected)
         {
-            assertThat(expected).isSameAs(ex);
+            assertThat(expected.getErrors()).hasSize(2)
+                    .contains(entry(link1, ex1), entry(link2, ex2));
         }
     }
-
-    private JiraService setupJqlTest(String jsonResponse) throws Exception
+    
+    @Test
+    public void testDoesIssueMatchJqlQuery_multipleAppLinks_showNotFoundWhereSomeErrors() throws Exception
     {
-        when(applicationLinkService.getPrimaryApplicationLink(JiraApplicationType.class)
-                .createAuthenticatedRequestFactory().createRequest(Request.MethodType.POST, "/rest/api/2/search"))
-                .thenReturn(applicationLinkRequest);
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        ResponseException ex1 = mock(ResponseException.class);
+        setupJqlTest(link1, ex1);
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        setupJqlTest(link2, "{\"issues\": []}");
+        
+        setApplicationLinks(link1, link2);
+        
+        try
+        {
+            jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123"));
+            Assert.fail("Exception not thrown");
+        }
+        catch (JiraLookupsException expected)
+        {
+            Map<ApplicationLink, Exception> errors = expected.getErrors();
+            assertThat(errors).hasSize(2);
+            assertThat(errors).contains(entry(link1, ex1));
+            assertThat(errors).containsKey(link2);
+            assertThat(errors.get(link2)).hasMessage("TEST-123: JIRA issue does not match JQL query: project = TEST");
+        }
+    }
+    
+    @Test
+    public void testDoesIssueMatchJqlQuery_JQLExceptionMissingJIRA() throws Exception
+    {
+        IssueKey issue = new IssueKey("TEST", "123");
+        ApplicationLink link = setupApplicationLink();
+        JiraExecutionException ex = mock(JiraExecutionException.class);
+        when(ex.getJiraErrors()).thenReturn(ImmutableList.of(issue.getFullyQualifiedIssueKey()));
+        setupJqlTest(link, ex);
+        
+        assertThat(jiraService.doesIssueMatchJqlQuery(("project = TEST"), issue)).isFalse();
+    }
+    
+    @Test
+    public void testDoesIssueMatchJqlQuery_JQLException_ErrorsAreCaptured() throws Exception
+    {
+        ApplicationLink link = setupApplicationLink();
+        JiraExecutionException ex = mock(JiraExecutionException.class);
+        when(ex.getJiraErrors()).thenReturn(ImmutableList.of("JQL error"));
+        setupJqlTest(link, ex);
+        
+        try
+        {
+            jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123"));
+            Assert.fail("Exception not thrown");
+        }
+        catch (JiraLookupsException expected)
+        {
+            assertThat(expected.getErrors()).hasSize(1)
+                    .contains(entry(link, ex));
+        }
+    }
+        
+    @Test
+    public void testDoesIssueMatchJqlQuery_JQLException_MultipleErrorsAreCaptured() throws Exception
+    {
+        IssueKey issue = new IssueKey("TEST", "123");
+        ApplicationLink link = setupApplicationLink();
+        JiraExecutionException ex = mock(JiraExecutionException.class);
+        when(ex.getJiraErrors()).thenReturn(ImmutableList.of(issue.getFullyQualifiedIssueKey(), "JQL error"));
+        setupJqlTest(link, ex);
+        
+        try
+        {
+            jiraService.doesIssueMatchJqlQuery("project = TEST", new IssueKey("TEST", "123"));
+            Assert.fail("Exception not thrown");
+        }
+        catch (JiraLookupsException expected)
+        {
+            assertThat(expected.getErrors()).hasSize(1)
+                    .contains(entry(link, ex));
+        }
+    }
+    
+    @Test
+    public void testCheckJqlQuery_returnsNoErrorsIfValid() throws Exception
+    {
+        ApplicationLink link = setupApplicationLink();
+        
+        setupJqlTest(link, "");
+        
+        assertThat(jiraService.checkJqlQuery("assignee is not empty")).isEmpty();
+    }
 
-        jiraService = new JiraServiceImpl(applicationLinkService);
+    @Test
+    public void testCheckJqlQuery_returnsFalseIfNotValid() throws Exception
+    {
+        ApplicationLink link = setupApplicationLink();
+        
+        Response resp = mockResponse("{\"errorMessages\":[\"Query error.\"]}", 400);
+        setupJqlTest(link, resp);
+        
+        List<String> errors = jiraService.checkJqlQuery("invalid jql query@#%$");
+        assertThat(errors).containsOnly("MOCK JIRA: Query error.");
+    }
 
-        when(applicationLinkRequest.execute()).thenReturn(jsonResponse);
+    @Test
+    public void testCheckJqlQuery_unknownExceptionsAreReported() throws Exception
+    {
+        ApplicationLink link = setupApplicationLink();
+        
+        ResponseStatusException ex = mock(ResponseStatusException.class, RETURNS_DEEP_STUBS);
+        when(ex.getResponse().getStatusCode()).thenReturn(500);
+        when(ex.getResponse().getStatusText()).thenReturn("ERROR");
+        
+        setupJqlTest(link, ex);
+        List<String> errors = jiraService.checkJqlQuery("jql query");
 
-        return jiraService;
+        assertThat(errors).containsOnly("MOCK JIRA: ERROR");
+    }
+    
+    @Test
+    public void testCheckJqlQuery_multipleAppLinks_fallThrough() throws Exception
+    {
+        ResponseException ex = mock(ResponseException.class);
+        when(ex.getMessage()).thenReturn("INTERNAL ERROR");
+        
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        setupJqlTest(link1, ex);
+        
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        setupJqlTest(link2, "");
+        
+        setApplicationLinks(link1, link2);
+        
+        assertThat(jiraService.checkJqlQuery("assignee is not empty")).isEmpty();
+    }
+    
+    @Test
+    public void testCheckJqlQuery_multipleAppLinks_stopAfterSuccess() throws Exception
+    {
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        setupJqlTest(link1, "");
+        
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        
+        setApplicationLinks(link1, link2);
+        
+        assertThat(jiraService.checkJqlQuery("assignee is not empty")).isEmpty();
+        
+        verifyNoMoreInteractions(link2);
+    }
+    
+    @Test
+    public void testCheckJqlQuery_multipleAppLinks_allErrorsAreCaptured() throws Exception
+    {
+        ApplicationLink link1 = mockApplicationLink("JIRA1");
+        Response resp1 = mockResponse("", 500);
+        setupJqlTest(link1, resp1);
+
+        ApplicationLink link2 = mockApplicationLink("JIRA2");
+        Response resp2 = mockResponse("", 501);
+        setupJqlTest(link2, resp2);
+        
+        setApplicationLinks(link1, link2);
+
+        assertThat(jiraService.checkJqlQuery("jql query"))
+                .containsOnly("JIRA1: STATUS 500", "JIRA2: STATUS 501");
+    }
+    
+    private void setApplicationLinks(@Nonnull ApplicationLink... links)
+    {
+        when(applicationLinkService.getPrimaryApplicationLink(JiraApplicationType.class)).thenReturn(links[0]);
+        when(applicationLinkService.getApplicationLinks(JiraApplicationType.class)).thenReturn(ImmutableList.copyOf(links));
+    }
+    
+    @Nonnull
+    private ApplicationLink mockApplicationLink(@Nonnull final String name)
+    {
+        ApplicationLink link = mock(ApplicationLink.class);
+        when(link.getName()).thenReturn(name);
+        ApplicationLinkRequestFactory fac = mock(ApplicationLinkRequestFactory.class);
+        when(link.createAuthenticatedRequestFactory()).thenReturn(fac);
+        return link;
+    }
+    
+    @Nonnull
+    private ApplicationLink setupApplicationLink()
+    {
+        ApplicationLink link = mockApplicationLink("MOCK JIRA");
+        setApplicationLinks(link);
+        
+        return link;
+    }
+
+    @Nonnull
+    private ApplicationLinkRequest setupJqlTest(@Nonnull final ApplicationLink link, @Nonnull final String jsonResponse) throws Exception
+    {
+        Response response = mockResponse(jsonResponse, 200);
+        return setupJqlTest(link, response);
+    }
+    
+    @Nonnull
+    private ApplicationLinkRequest setupJqlTest(@Nonnull final ApplicationLink link, @Nonnull final Response response) throws Exception
+    {
+        ApplicationLinkRequest req = mock(ApplicationLinkRequest.class);
+        when(link.createAuthenticatedRequestFactory().createRequest(Request.MethodType.POST, "/rest/api/2/search?fields=summary&validateQuery=false"))
+            .thenReturn(req);
+        
+        ArgumentCaptor<ReturningResponseHandler> respHandler = ArgumentCaptor.forClass(ReturningResponseHandler.class);
+        when(req.executeAndReturn(respHandler.capture())).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable
+            {
+                ReturningResponseHandler<Response, String> handler = (ReturningResponseHandler<Response, String>)invocation.getArguments()[0];
+
+                return handler.handle(response);
+            }
+        });
+
+        return req;
+    }
+    
+    @Nonnull
+    private ApplicationLinkRequest setupJqlTest(@Nonnull final ApplicationLink link, @Nonnull final Exception ex) throws Exception
+    {
+        ApplicationLinkRequest req = mock(ApplicationLinkRequest.class);
+        when(link.createAuthenticatedRequestFactory().createRequest(Request.MethodType.POST, "/rest/api/2/search?fields=summary&validateQuery=false"))
+            .thenReturn(req);
+
+        when(req.execute()).thenThrow(ex);
+        when(req.executeAndReturn(any(ReturningResponseHandler.class))).thenThrow(ex);
+
+        return req;
+    }
+    
+    @Nonnull
+    private ApplicationLinkRequest setupIssueTest(@Nonnull final ApplicationLink link, @Nonnull IssueKey issueKey, boolean exists) throws Exception
+    {
+        ApplicationLinkRequest req = mock(ApplicationLinkRequest.class);
+        when(link.createAuthenticatedRequestFactory().createRequest(Request.MethodType.GET, "/rest/api/2/issue/"+issueKey.getFullyQualifiedIssueKey()+"?fields=summary"))
+            .thenReturn(req);
+        
+        if (exists)
+        {
+            when(req.execute()).thenReturn("");
+        }
+        else
+        {
+            ResponseStatusException ex = mock(ResponseStatusException.class, RETURNS_DEEP_STUBS);
+            when(ex.getResponse().getStatusCode()).thenReturn(404);
+        }
+        
+        return req;
+    }
+    
+    @Nonnull
+    private Response mockResponse(@Nonnull final String jsonResponse, final int statusCode) throws ResponseException
+    {
+        Response response = mock(Response.class);
+        when(response.getResponseBodyAsString()).thenReturn(jsonResponse);
+        when(response.getResponseBodyAsStream()).thenReturn(new ByteArrayInputStream(jsonResponse.getBytes()));
+        when(response.getStatusCode()).thenReturn(statusCode);
+        when(response.getStatusText()).thenReturn("STATUS " + statusCode);
+        when(response.isSuccessful()).thenReturn(statusCode >= 200 && statusCode < 300);
+        
+        return response;
     }
 }


### PR DESCRIPTION
Currently YACC only grabs the first JIRA instance (via the primary application link). This means that if Stash is linked to multiple JIRA instances, only the first is checked.

This PR uses all the application links instead. Its careful to keep iterating through all of the application links when there is an error, and only report an error if there are no matches. There are a few reasons for this:
- Some JQL statements (eg using custom fields) might not be valid in all linked JIRAs
- JIRA returns an error from the /search REST api when the issue doesn't exist, and older versions don't allow that behaviour to be disabled.
- A user may not have access to all linked JIRA instances

This is a large change, but its mostly mechanical:
- Most of the changes moves the translation from JIRA/application link exceptions to strings into a central place (JiraLookupsException.getPrintableErrors), and resulting cleanups
- The ErrorParsingReturningResponseHandler is needed to capture the error response, since the default Atlassian stuff seemed to drop the error message (and using the stream also stops logging warnings into the logs on each request, although that might be a dev-only thing)
- There's a fair bit of whitespace changes
- The tests got a lot of changes/enhancements

This has _only_ been tested on my desktop with two dev JIRA instances - I've done this in preparation for a JIRA migration/upgrade at work, but the second instance won't be set up there for another few weeks. Consider this a preview :)

There are some optimisations that could be done (eg trying the JQL query before the issue lookup, to reduce the number of queries done), but they are independent, and this was getting large enough....
