### PR TITLE
Suggested change to more descriptive error messages explaining how to fi...

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -301,8 +301,8 @@ public class YaccServiceImpl implements YaccService
 
         if (requireMatchingAuthorEmail && !changeset.getCommitter().getEmailAddress().toLowerCase().equals(stashUser.getEmailAddress().toLowerCase()))
         {
-            errors.add(String.format("expected committer email '%s' but found '%s'", stashUser.getEmailAddress(),
-                    changeset.getCommitter().getEmailAddress()));
+            errors.add(String.format("expected committer email '%s' but found '%s'.  To correct this error type: git config --global user.email \"%s\"", stashUser.getEmailAddress(),
+                    changeset.getCommitter().getEmailAddress(), stashUser.getEmailAddress()));
         }
 
         return errors;
@@ -319,8 +319,8 @@ public class YaccServiceImpl implements YaccService
 
         if (requireMatchingAuthorName && !changeset.getCommitter().getName().toLowerCase().equals(stashUser.getDisplayName().toLowerCase()))
         {
-            errors.add(String.format("expected committer name '%s' but found '%s'", stashUser.getDisplayName(),
-                    changeset.getCommitter().getName()));
+            errors.add(String.format("expected committer name '%s' but found '%s'.  To correct this error type: git config --global user.name \"%s\"", stashUser.getDisplayName(),
+                    changeset.getCommitter().getName(), stashUser.getDisplayName()));
         }
 
         return errors;

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -75,7 +75,7 @@ public class YaccServiceImplTest
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<String> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-       	assertThat(errors).contains("refs/heads/master: deadbeef: expected committer name 'John Smith' but found 'Incorrect Name'");
+       	assertThat(errors).contains("refs/heads/master: deadbeef: expected committer name 'John Smith' but found 'Incorrect Name'.  To correct this error type: git config --global user.name \"John Smith\"");
     }
 
     @Test
@@ -120,7 +120,7 @@ public class YaccServiceImplTest
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
 		List<String> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-		assertThat(errors).contains("refs/heads/master: deadbeef: expected committer email 'correct@email.com' but found 'wrong@email.com'");
+		assertThat(errors).contains("refs/heads/master: deadbeef: expected committer email 'correct@email.com' but found 'wrong@email.com'.  To correct this error type: git config --global user.email \"correct@email.com\"");
     }
 
     @Test
@@ -424,9 +424,10 @@ public class YaccServiceImplTest
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<String> errors = yaccService.checkRefChange(null, settings, mockTagChange());
-        assertThat(errors).contains("refs/tags/tag: deadbeef: expected committer name 'John Smith' but found 'Incorrect Name'");
-        assertThat(errors).contains("refs/tags/tag: deadbeef: expected committer email 'correct@email.com' but found 'wrong@email.com'");
+        assertThat(errors).contains("refs/tags/tag: deadbeef: expected committer name 'John Smith' but found 'Incorrect Name'.  To correct this error type: git config --global user.name \"John Smith\"");
+        assertThat(errors).contains("refs/tags/tag: deadbeef: expected committer email 'correct@email.com' but found 'wrong@email.com'.  To correct this error type: git config --global user.email \"correct@email.com\"");
     }
+
 
     @Test
     public void testCheckRefChange_tag_doesntCheckRegex() throws Exception


### PR DESCRIPTION
I changed the error message on the Name and Email mismatch errors to add additional line of text describing how to correct the error, specifically what git command to type.  I've run into use cases where this could be useful especially for folks transitioning over from CVS who don't want to read any directions.  I leave it up to you as to whether you think this would be a useful change.

Thanks!
