### PR TITLE
Add PreReceive hook at system level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,18 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+
+		<dependency>
+			<groupId>com.atlassian.stash</groupId>
+			<artifactId>stash-service-impl</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
         <dependency>
             <groupId>com.atlassian.stash</groupId>
             <artifactId>stash-api</artifactId>

--- a/src/main/java/com/isroot/stash/plugin/ConfigServlet.java
+++ b/src/main/java/com/isroot/stash/plugin/ConfigServlet.java
@@ -1,0 +1,186 @@
+package com.isroot.stash.plugin;
+
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import com.atlassian.soy.renderer.SoyException;
+import com.atlassian.soy.renderer.SoyTemplateRenderer;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.stash.setting.Settings;
+import com.atlassian.stash.setting.SettingsValidationErrors;
+import com.atlassian.stash.server.ApplicationPropertiesService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.atlassian.stash.nav.NavBuilder;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.atlassian.stash.hook.repository.RepositoryHookService;
+
+
+public class ConfigServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private final RepositoryHookService repositoryHookService;
+    private static final Logger log = LoggerFactory.getLogger(ConfigServlet.class);
+    final private SoyTemplateRenderer soyTemplateRenderer;
+    //    private final ApplicationPropertiesService applicationPropertiesService;
+    private final JiraService jiraService;
+    private final NavBuilder navBuilder;
+    Settings settings;
+    ConfigValidator configValidator;
+    private Map<String, String> fields;
+    private Map<String, Iterable<String>> fieldErrors;
+    private final PluginSettings pluginSettings;
+    static final String SETTINGS_MAP="com.isroot.stash.plugin.yacc.settings";
+    HashMap<String, Object> settingsMap;
+
+    public ConfigServlet(SoyTemplateRenderer soyTemplateRenderer,
+            PluginSettingsFactory pluginSettingsFactory,
+            ApplicationPropertiesService applicationPropertiesService,
+            JiraService jiraService,
+            RepositoryHookService repositoryHookService,
+            NavBuilder navBuilder
+    )
+    {
+        this.soyTemplateRenderer = soyTemplateRenderer;
+        this.jiraService = jiraService;
+        this.navBuilder= navBuilder;
+        this.repositoryHookService = repositoryHookService;
+
+        pluginSettings = pluginSettingsFactory.createGlobalSettings();
+
+        configValidator=new ConfigValidator(jiraService);
+
+
+        fields = new HashMap<String, String>();
+        fieldErrors=new HashMap<String, Iterable<String>>();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+    {
+        log.debug("doGet");
+        settingsMap = (HashMap<String, Object>) pluginSettings.get(SETTINGS_MAP);
+        if(settingsMap == null) {
+            settingsMap = new HashMap<String, Object>();
+        }
+        settings=repositoryHookService.createSettingsBuilder()
+                .addAll(settingsMap)
+                .build();
+        //    settings=new MapSettingsBuilder().addAll(settingsMap).build();
+        //configValidator.validate(settings, new SettingsValidationErrorsImpl(errors), null);
+        configValidator.validate(settings, new SettingsValidationErrorsImpl(fieldErrors), null);
+        doGetContinue(req,resp);
+    }
+    protected void doGetContinue(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+    {
+        log.debug("doGetContinue");
+        fields.clear();
+
+        for (Map.Entry<String, Object> entry : settingsMap.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if(value instanceof String){
+                fields.put(key,(String)value);
+            }
+        }
+
+
+        log.debug("Config fields: "+fields);
+        log.debug("Field errors: "+fieldErrors);
+
+        resp.setContentType("text/html;charset=UTF-8");
+        try
+        {
+            soyTemplateRenderer.render(resp.getWriter(), "com.isroot.stash.plugin.yacc:yaccHook-config-serverside", "com.atlassian.stash.repository.hook.ref.config", 
+                    ImmutableMap
+                    .<String, Object>builder()
+                    .put("config",fields)
+                    .put("errors",fieldErrors)
+                    .build()
+            );
+            return;
+        } catch (SoyException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            throw new ServletException(e);
+        }
+
+    }
+
+    void addStringFieldValue(HashMap<String, Object> settingsMap,HttpServletRequest req,String fieldName) {
+        String o;
+        o=req.getParameter(fieldName);
+        if(o!=null && !o.isEmpty())settingsMap.put(fieldName,o);
+    }
+
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+    {
+        settingsMap.clear();
+
+        addStringFieldValue(settingsMap,req,"requireMatchingAuthorEmail");
+        addStringFieldValue(settingsMap,req,"requireMatchingAuthorName");
+        addStringFieldValue(settingsMap,req,"commitMessageRegex");
+        addStringFieldValue(settingsMap,req,"requireJiraIssue");
+        addStringFieldValue(settingsMap,req,"ignoreUnknownIssueProjectKeys");
+        addStringFieldValue(settingsMap,req,"issueJqlMatcher");
+        addStringFieldValue(settingsMap,req,"excludeMergeCommits");
+        addStringFieldValue(settingsMap,req,"excludeByRegex");
+        addStringFieldValue(settingsMap,req,"excludeServiceUserCommits");
+
+        settings=repositoryHookService.createSettingsBuilder()
+                .addAll(settingsMap)
+                .build();
+
+        configValidator.validate(settings, new SettingsValidationErrorsImpl(fieldErrors), null);
+
+        if (fieldErrors.size()>0) {
+            doGetContinue(req,resp);
+            return;
+        }
+        pluginSettings.put(SETTINGS_MAP, settingsMap);
+        String redirectUrl;
+        redirectUrl=navBuilder.addons().buildRelative();        
+        log.debug("redirect: "+redirectUrl);
+        resp.sendRedirect(redirectUrl);
+    }
+    private static class SettingsValidationErrorsImpl implements SettingsValidationErrors {
+
+        Map<String, Iterable<String>> fieldErrors;
+        public SettingsValidationErrorsImpl(Map<String, Iterable<String>> fieldErrors) {
+            this.fieldErrors=fieldErrors;
+            this.fieldErrors.clear();
+        }
+
+        @Override
+        public void addFieldError(String fieldName, String errorMessage) {
+            fieldErrors.put(fieldName, new ArrayList<String>(Arrays.asList(errorMessage)));
+        }
+
+        @Override
+        public void addFormError(String errorMessage) {
+            //not implemented
+            return; 
+        }
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/ConfigServlet.java
+++ b/src/main/java/com/isroot/stash/plugin/ConfigServlet.java
@@ -98,6 +98,7 @@ public class ConfigServlet extends HttpServlet {
         for (Map.Entry<String, Object> entry : settingsMap.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
+            log.debug("got plugin config "+key+"="+value+" "+value.getClass().getName());
             if(value instanceof String){
                 fields.put(key,(String)value);
             }
@@ -138,6 +139,7 @@ public class ConfigServlet extends HttpServlet {
     {
         settingsMap.clear();
 
+        // Plugin settings persister supports onlt map of strings
         addStringFieldValue(settingsMap,req,"requireMatchingAuthorEmail");
         addStringFieldValue(settingsMap,req,"requireMatchingAuthorName");
         addStringFieldValue(settingsMap,req,"commitMessageRegex");
@@ -157,6 +159,11 @@ public class ConfigServlet extends HttpServlet {
         if (fieldErrors.size()>0) {
             doGetContinue(req,resp);
             return;
+        }
+        for (Map.Entry<String, Object> entry : settingsMap.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            log.debug("save plugin config "+key+"="+value+" "+value.getClass().getName());
         }
         pluginSettings.put(SETTINGS_MAP, settingsMap);
         String redirectUrl;

--- a/src/main/java/com/isroot/stash/plugin/YaccHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccHook.java
@@ -45,6 +45,7 @@ public final class YaccHook implements PreReceiveRepositoryHook
     public boolean onReceive(@Nonnull RepositoryHookContext repositoryHookContext,
                              @Nonnull Collection<RefChange> refChanges, @Nonnull HookResponse hookResponse)
     {
+        log.debug("On receive");
         List<String> errors = Lists.newArrayList();
 
         for (RefChange rf : refChanges)

--- a/src/main/java/com/isroot/stash/plugin/YaccHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccHook.java
@@ -65,7 +65,7 @@ public final class YaccHook implements PreReceiveRepositoryHook
         }
         else
         {
-            hookResponse.err().println(ERROR_BEARS);
+            //hookResponse.err().println(ERROR_BEARS);
 
             for (String error : errors)
             {

--- a/src/main/java/com/isroot/stash/plugin/YaccPreReceiveHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccPreReceiveHook.java
@@ -1,0 +1,102 @@
+package com.isroot.stash.plugin;
+
+import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.hook.HookResponse;
+import com.atlassian.stash.hook.PreReceiveHook;
+import com.atlassian.stash.hook.repository.RepositoryHook;
+import com.atlassian.stash.hook.repository.RepositoryHookService;
+import com.atlassian.stash.hook.repository.RepositoryHookContext;
+import com.atlassian.stash.repository.RefChange;
+import com.atlassian.stash.repository.RefChangeType;
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.stash.user.Permission;
+import com.atlassian.stash.user.SecurityService;
+import com.atlassian.stash.util.UncheckedOperation;
+import com.atlassian.stash.setting.Settings;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.HashMap;
+
+/**
+ * @author Sean Ford
+ * @since 2013-05-11
+ */
+public final class YaccPreReceiveHook implements PreReceiveHook
+{
+    private static final Logger log = LoggerFactory.getLogger(YaccPreReceiveHook.class);
+
+    public static final String ERROR_BEARS = "\n" +
+            "  (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c) \n" +
+            "   / ._. \\      / ._. \\      / ._. \\      / ._. \\      / ._. \\ \n" +
+            " __\\( Y )/__  __\\( Y )/__  __\\( Y )/__  __\\( Y )/__  __\\( Y )/__\n" +
+            "(_.-/'-'\\-._)(_.-/'-'\\-._)(_.-/'-'\\-._)(_.-/'-'\\-._)(_.-/'-'\\-._)\n" +
+            "   || E ||      || R ||      || R ||      || O ||      || R ||\n" +
+            " _.' `-' '._  _.' `-' '._  _.' `-' '._  _.' `-' '._  _.' `-' '.\n" +
+            "(.-./`-'\\.-.)(.-./`-`\\.-.)(.-./`-`\\.-.)(.-./`-'\\.-.)(.-./`-`\\.-.)\n" +
+            " `-'     `-'  `-'     `-'  `-'     `-'  `-'     `-'  `-'     `-' \n" +
+            "\n" +
+            "\n" +
+            "Push rejected.\n";
+
+    private final  YaccHook yaccHook;
+    private final PluginSettingsFactory pluginSettingsFactory;
+    private final SecurityService securityService;
+    private final RepositoryHookService repositoryHookService;
+
+    public YaccPreReceiveHook(YaccService yaccService,
+        PluginSettingsFactory pluginSettingsFactory,
+        SecurityService securityService,
+        RepositoryHookService repositoryHookService
+    )
+    {
+        yaccHook=new YaccHook(yaccService);
+        this.pluginSettingsFactory = pluginSettingsFactory;
+        this.securityService = securityService;
+        this.repositoryHookService = repositoryHookService;
+    }
+
+    @Override
+    public boolean onReceive(final Repository repository,
+                             @Nonnull Collection<RefChange> refChanges, @Nonnull HookResponse hookResponse)
+    {
+        RepositoryHook hook= securityService.withPermission(Permission.REPO_ADMIN,"Get plugin configuration").call(new UncheckedOperation<RepositoryHook>(){
+            public RepositoryHook perform() {
+                return repositoryHookService.getByKey(repository, "com.isroot.stash.plugin.yacc:yaccHook");
+            }
+        });
+        Settings settings;
+        if(hook.isEnabled() && hook.isConfigured()) {
+            // Repository hook is configured and enabled. 
+            // Repository hook overrides default pre-receive hook configuration
+            log.debug("PreReceiveRepositoryHook configured. Skip PreReceiveHook");
+            return true;    
+            //settings = repositoryHookService.getSettings(repository, "com.teslamotors.stash.hook.jira-issue-enforcer:commit-message-issue-enforcer");
+        } else {
+            // Repository hook not configured
+            log.debug("PreReceiveRepositoryHook not configured. Run PreReceiveHook");
+            PluginSettings pluginSettings;
+            pluginSettings = pluginSettingsFactory.createGlobalSettings();
+            
+            @SuppressWarnings("unchecked")
+            HashMap<String, Object> config = (HashMap<String, Object>) pluginSettings.get(ConfigServlet.SETTINGS_MAP);
+            if(config == null) {
+                // Server configuration not stored    
+                config = new HashMap<String, Object>();
+            }
+            /* Watershed commits are not relevant in global hook configuration context */
+            settings=repositoryHookService.createSettingsBuilder()
+                    .addAll(config)
+                    .build();
+        }
+
+        return yaccHook.onReceive(new RepositoryHookContext(repository,settings),refChanges,hookResponse);
+
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/YaccPreReceiveHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccPreReceiveHook.java
@@ -32,19 +32,6 @@ public final class YaccPreReceiveHook implements PreReceiveHook
 {
     private static final Logger log = LoggerFactory.getLogger(YaccPreReceiveHook.class);
 
-    public static final String ERROR_BEARS = "\n" +
-            "  (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c) \n" +
-            "   / ._. \\      / ._. \\      / ._. \\      / ._. \\      / ._. \\ \n" +
-            " __\\( Y )/__  __\\( Y )/__  __\\( Y )/__  __\\( Y )/__  __\\( Y )/__\n" +
-            "(_.-/'-'\\-._)(_.-/'-'\\-._)(_.-/'-'\\-._)(_.-/'-'\\-._)(_.-/'-'\\-._)\n" +
-            "   || E ||      || R ||      || R ||      || O ||      || R ||\n" +
-            " _.' `-' '._  _.' `-' '._  _.' `-' '._  _.' `-' '._  _.' `-' '.\n" +
-            "(.-./`-'\\.-.)(.-./`-`\\.-.)(.-./`-`\\.-.)(.-./`-'\\.-.)(.-./`-`\\.-.)\n" +
-            " `-'     `-'  `-'     `-'  `-'     `-'  `-'     `-'  `-'     `-' \n" +
-            "\n" +
-            "\n" +
-            "Push rejected.\n";
-
     private final  YaccHook yaccHook;
     private final PluginSettingsFactory pluginSettingsFactory;
     private final SecurityService securityService;

--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -52,6 +52,12 @@ public class YaccServiceImpl implements YaccService
 
         List<String> errors = Lists.newArrayList();
 
+        if( "0000000000000000000000000000000000000000".equals(refChange.getFromHash()) && !isTag ) {
+            // New branch can be created by anyone from any commit
+            log.debug("Skip checking message or author if this is new branch");
+            return errors;
+        }
+
         Set<YaccChangeset> changesets = changesetsService.getNewChangesets(repository, refChange);
 
         for (YaccChangeset changeset : changesets)

--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.net.SocketTimeoutException;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -278,6 +279,8 @@ public class YaccServiceImpl implements YaccService
                 CredentialsRequiredException cred = (CredentialsRequiredException)e.getCause();
                 errors.add(String.format("%s: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA.", issueKey.getFullyQualifiedIssueKey()));
                 errors.add(String.format("To authenticate, visit %s in a web browser.", cred.getAuthorisationURI().toASCIIString()));
+            } else if(e.getCause() instanceof SocketTimeoutException) {
+                log.error("JIRA communication error. Assume issue exsists to avoid denay of service", e);
             } else {
                 log.error("unexpected exception while trying to validate JIRA issue", e);
                 errors.add(String.format("%s: Unable to validate JIRA issue due to an unexpected exception. Please see stack trace in logs.", issueKey.getFullyQualifiedIssueKey()));

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -5,6 +5,7 @@
         <vendor name="${project.organization.name}" url="${project.organization.url}" />
         <param name="plugin-icon">images/pluginIcon.png</param>
         <param name="plugin-logo">images/pluginLogo.png</param>
+        <param name="configure.url">/plugins/servlet/yaccHook/config</param>
     </plugin-info>
 
     <!-- add our i18n resource -->
@@ -20,6 +21,20 @@
 
         <context>yacc</context>
     </web-resource>
+
+        <servlet key="yaccHook-config-servlet" name="YaccHook Configuration Servlet" class="com.isroot.stash.plugin.ConfigServlet">
+                <url-pattern>/yaccHook/*</url-pattern>
+        </servlet>
+
+    <stash-resource key="yaccHook-config-serverside">
+        <directory location="/static/">
+            <include>/**/simple.soy</include>
+            <include>/**/serverside-config.soy</include>
+        </directory>
+        <dependency>com.atlassian.stash.stash-web-plugin:server-soy-templates</dependency>
+        <dependency>com.atlassian.stash.stash-web-plugin:global</dependency>
+    </stash-resource>
+
     
     <!-- import from the product container -->
     <component-import key="applicationProperties" interface="com.atlassian.sal.api.ApplicationProperties" />
@@ -37,13 +52,27 @@
     <component key="yaccService" class="com.isroot.stash.plugin.YaccServiceImpl" public="true">
         <interface>com.isroot.stash.plugin.YaccService</interface>
     </component>
+    <component-import key="soyTemplateRenderer" interface="com.atlassian.soy.renderer.SoyTemplateRenderer"/>
 
 	<repository-hook key="yaccHook" name="Yet Another Commit Checker"  class="com.isroot.stash.plugin.YaccHook">
 		<description>Yet Another Commit Checker pre-receive hook.</description>
+                <icon>images/pluginLogo.png</icon>
 		<config-form name="Yacc Hook Config" key="yaccHook-config">
 			<view>com.atlassian.stash.repository.hook.ref.formContents</view>
 			<directory location="/static/" />
 		</config-form>
 		<validator>com.isroot.stash.plugin.ConfigValidator</validator>
 	</repository-hook>
+
+        <pre-receive-hook key="yaccPreReceiveHook" name="Yet Another Commit Checker"  class="com.isroot.stash.plugin.YaccPreReceiveHook">
+		<description>Yet Another Commit Checker pre-receive hook.</description>
+                <icon>images/pluginLogo.png</icon>
+
+		<config-form name="Yacc Hook Config" key="yaccHook-config">
+			<view>com.atlassian.stash.repository.hook.ref.formContents</view>
+                        <directory location="/static/" />
+                </config-form>
+		<validator>com.isroot.stash.plugin.ConfigValidator</validator>
+        </pre-receive-hook>
+
 </atlassian-plugin>

--- a/src/main/resources/static/serverside-config.soy
+++ b/src/main/resources/static/serverside-config.soy
@@ -1,0 +1,43 @@
+{namespace com.atlassian.stash.repository.hook.ref}
+
+/**
+ * @param config
+ * @param? errors
+ **/
+{template .config}
+<html>
+    <head>
+        <meta name="decorator" content="atl.admin">
+        <title>Yet Another Commit Checker</title>
+    </head>
+    <body>
+	{call aui.group.group}
+	{param content}
+        {call widget.aui.form.form}
+	        {param action: '' /}
+	        {param content}
+		        <h2>Yet Another Commit Checker default configuration. Repository hook configuration wins.</h2>
+		        {call .formContents}
+	        		{param config: $config /}
+	        		{param errors: $errors /}
+			{/call}
+                                {call widget.aui.form.buttons}
+                                    {param content}
+                                        {call widget.aui.form.submit}
+                                            {param id: 'submit' /}
+                                            {param isPrimary: true /}
+                                            {param accessKey: 's' /}
+                                            {param label: stash_i18n('stash.web.button.save', 'Save') /}
+                                        {/call}
+                                        {call widget.aui.form.cancelButton}
+                                            {param href: nav_admin() /}
+                                        {/call}
+                                    {/param}
+                                {/call}
+		{/param}
+	{/call}
+	{/param}
+	{/call}
+    </body>
+</html>
+{/template}

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccHookTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccHookTest.java
@@ -74,7 +74,7 @@ public class YaccHookTest
 
 		yaccHook.onReceive(repositoryHookContext, Lists.newArrayList(mock(RefChange.class)), hookResponse);
 
-		verify(hookResponse.err()).println(YaccHook.ERROR_BEARS);
+		//verify(hookResponse.err()).println(YaccHook.ERROR_BEARS);
 		verify(hookResponse.err()).println("error1");
 		verify(hookResponse.err()).println("error2");
 	}


### PR DESCRIPTION
We have 1000+ repositories in one project. Plugin handles policy for all repositories at system level. Configuration still can be enabled at repository level. 
Skip commit author checking when pushing new branch.
