### PR TITLE
Fix error when deleting a tag that doesn't exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.atlassian.stash</groupId>
+            <artifactId>stash-scm-git-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.atlassian.applinks</groupId>
             <artifactId>applinks-api</artifactId>
             <scope>provided</scope>

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccHookTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccHookTest.java
@@ -64,6 +64,17 @@ public class YaccHookTest {
     }
 
     @Test
+    public void testOnReceive_NullRefChangesIgnored() {
+        RefChange refChange = mock(RefChange.class);
+        when(refChange.getType()).thenReturn(RefChangeType.ADD);
+        when(refChange.getToHash()).thenReturn("0000000000000000000000000000000000000000");
+
+        boolean allowed = yaccHook.onReceive(repositoryHookContext, Lists.newArrayList(refChange), null);
+        assertThat(allowed).isTrue();
+        verifyZeroInteractions(yaccService);
+    }
+
+    @Test
     public void testOnReceive_pushRejectedIfThereAreErrors() {
         when(yaccService.checkRefChange(any(Repository.class), any(Settings.class), any(RefChange.class)))
                 .thenReturn(Lists.newArrayList(new YaccError("error with commit")));


### PR DESCRIPTION
This fixes an error when trying to delete a tag that doesn't exist, ie:

$ git push origin :refs/tags/x
remote: Hook com.isroot.stash.plugin.YaccHook failed. Error: 
remote: org.eclipse.jgit.errors.MissingObjectException: Missing unknown 0000000000000000000000000000000000000000
To http://admin@localhost:7990/stash/scm/project_1/rep_1.git
 ! [remote rejected] x (pre-receive hook declined)
error: failed to push some refs to 'http://admin@localhost:7990/stash/scm/project_1/rep_1.git'
