### PR TITLE
Migrate from fest to assertj

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert-core</artifactId>
-            <version>2.0M10</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/ut/com/isroot/stash/plugin/IssueKeyTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/IssueKeyTest.java
@@ -1,30 +1,26 @@
 package ut.com.isroot.stash.plugin;
 
-import com.google.common.collect.Lists;
 import com.isroot.stash.plugin.InvalidIssueKeyException;
 import com.isroot.stash.plugin.IssueKey;
 import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class IssueKeyTest {
     @Test
     public void testParseIssueKeys() {
         final List<IssueKey> issueKeys = IssueKey.parseIssueKeys("Issue: ABC-123, CBA-321, UNDER_SCORE-123;");
-        assertEquals(issueKeys, Lists.newArrayList(new IssueKey("ABC", "123"),
-                new IssueKey("CBA", "321"), new IssueKey("UNDER_SCORE", "123")));
+        assertThat(issueKeys).containsExactly(new IssueKey("ABC", "123"),
+                new IssueKey("CBA", "321"), new IssueKey("UNDER_SCORE", "123"));
     }
 
     @Test
     public void testParseValidIssueKey() throws InvalidIssueKeyException {
         final IssueKey parsed = new IssueKey("ABC-123");
-        assertEquals("ABC", parsed.getProjectKey());
-        assertEquals("123", parsed.getIssueId());
+        assertThat(parsed.getProjectKey()).isEqualTo("ABC");
+        assertThat(parsed.getIssueId()).isEqualTo("123");
     }
 
     @Test(expected = InvalidIssueKeyException.class)
@@ -34,21 +30,21 @@ public class IssueKeyTest {
 
     @Test
     public void testGetFullyQualifiedIssueKey() throws InvalidIssueKeyException {
-        assertEquals("ABC-123", new IssueKey("ABC", "123").getFullyQualifiedIssueKey());
-        assertEquals("ABC-123", new IssueKey("ABC-123").getFullyQualifiedIssueKey());
+        assertThat(new IssueKey("ABC", "123").getFullyQualifiedIssueKey()).isEqualTo("ABC-123");
+        assertThat(new IssueKey("ABC-123").getFullyQualifiedIssueKey()).isEqualTo("ABC-123");
     }
 
     @Test
     public void testEquality() throws InvalidIssueKeyException {
-        assertEquals(new IssueKey("ABC-123"), new IssueKey("ABC-123"));
-        assertEquals(new IssueKey("ABC-123").hashCode(), new IssueKey("ABC-123").hashCode());
+        assertThat(new IssueKey("ABC-123")).isEqualTo(new IssueKey("ABC-123"));
+        assertThat(new IssueKey("ABC-123").hashCode()).isEqualTo(new IssueKey("ABC-123").hashCode());
 
         /* Differs by issueId */
-        assertThat(new IssueKey("ABC-123"), is(not(new IssueKey("ABC-321"))));
-        assertThat(new IssueKey("ABC-123").hashCode(), is(not(new IssueKey("ABC-321").hashCode())));
+        assertThat(new IssueKey("ABC-123")).isNotEqualTo(new IssueKey("ABC-321"));
+        assertThat(new IssueKey("ABC-123").hashCode()).isNotEqualTo(new IssueKey("ABC-321").hashCode());
 
         /* Differs by projectKey */
-        assertThat(new IssueKey("ABC-123"), is(not(new IssueKey("CBA-123"))));
-        assertThat(new IssueKey("ABC-123").hashCode(), is(not(new IssueKey("CBA-123").hashCode())));
+        assertThat(new IssueKey("ABC-123")).isNotEqualTo(new IssueKey("CBA-123"));
+        assertThat(new IssueKey("ABC-123").hashCode()).isNotEqualTo(new IssueKey("CBA-123").hashCode());
     }
 }

--- a/src/test/java/ut/com/isroot/stash/plugin/JiraServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/JiraServiceImplTest.java
@@ -9,7 +9,7 @@ import com.atlassian.sal.api.net.ResponseStatusException;
 import com.isroot.stash.plugin.IssueKey;
 import com.isroot.stash.plugin.JiraService;
 import com.isroot.stash.plugin.JiraServiceImpl;
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -118,7 +118,7 @@ public class JiraServiceImplTest {
 
         try {
             jiraService.isJqlQueryValid("jql query");
-            Assert.fail();
+            Assertions.failBecauseExceptionWasNotThrown(ResponseStatusException.class);
         } catch(ResponseStatusException expected) {
             assertThat(expected).isSameAs(ex);
         }

--- a/src/test/java/ut/com/isroot/stash/plugin/JiraServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/JiraServiceImplTest.java
@@ -16,7 +16,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccChangesetTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccChangesetTest.java
@@ -3,7 +3,8 @@ package ut.com.isroot.stash.plugin;
 import com.isroot.stash.plugin.YaccChangeset;
 import com.isroot.stash.plugin.YaccPerson;
 import org.junit.Test;
-import static org.fest.assertions.api.Assertions.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccHookTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccHookTest.java
@@ -21,7 +21,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -26,7 +26,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Set;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -72,7 +72,7 @@ public class YaccServiceImplTest {
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError(YaccError.Type.COMMITTER_NAME,
+        assertThat(errors).containsOnly(new YaccError(YaccError.Type.COMMITTER_NAME,
                 "deadbeef: expected committer name 'John Smith' but found 'Incorrect Name'"));
     }
 
@@ -130,7 +130,7 @@ public class YaccServiceImplTest {
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError(YaccError.Type.COMMITTER_EMAIL,
+        assertThat(errors).containsOnly(new YaccError(YaccError.Type.COMMITTER_EMAIL,
                 "deadbeef: expected committer email 'correct@email.com' but found 'wrong@email.com'"));
     }
 
@@ -187,7 +187,7 @@ public class YaccServiceImplTest {
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(changesets);
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError("deadbeef: Unable to verify JIRA issue because JIRA Application Link does not exist"));
+        assertThat(errors).containsOnly(new YaccError("deadbeef: Unable to verify JIRA issue because JIRA Application Link does not exist"));
     }
 
     @Test
@@ -200,7 +200,7 @@ public class YaccServiceImplTest {
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError("deadbeef: No JIRA Issue found in commit message."));
+        assertThat(errors).containsOnly(new YaccError("deadbeef: No JIRA Issue found in commit message."));
     }
 
     @Test
@@ -236,7 +236,7 @@ public class YaccServiceImplTest {
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError("deadbeef: No JIRA Issue found in commit message."));
+        assertThat(errors).containsOnly(new YaccError("deadbeef: No JIRA Issue found in commit message."));
     }
 
     @Test
@@ -283,8 +283,8 @@ public class YaccServiceImplTest {
 
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError("deadbeef: ABC-123: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA."));
-        assertThat(errors).contains(new YaccError("deadbeef: To authenticate, visit http://localhost/link in a web browser."));
+        assertThat(errors).containsOnly(new YaccError("deadbeef: ABC-123: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA."),
+                                        new YaccError("deadbeef: To authenticate, visit http://localhost/link in a web browser."));
         verify(jiraService).doesIssueExist(new IssueKey("ABC-123"));
     }
 
@@ -302,8 +302,8 @@ public class YaccServiceImplTest {
 
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError("deadbeef: ABC-123: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA."));
-        assertThat(errors).contains(new YaccError("deadbeef: To authenticate, visit http://localhost/link in a web browser."));
+        assertThat(errors).containsOnly(new YaccError("deadbeef: ABC-123: Unable to validate JIRA issue because there was an authentication failure when communicating with JIRA."),
+                                        new YaccError("deadbeef: To authenticate, visit http://localhost/link in a web browser."));
         verify(jiraService).doesIssueExist(new IssueKey("ABC-123"));
     }
 
@@ -330,7 +330,7 @@ public class YaccServiceImplTest {
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockRefChange());
-        assertThat(errors).contains(new YaccError(YaccError.Type.COMMIT_REGEX,
+        assertThat(errors).containsOnly(new YaccError(YaccError.Type.COMMIT_REGEX,
                 "deadbeef: commit message doesn't match regex: [a-z ]+"));
     }
 
@@ -392,9 +392,9 @@ public class YaccServiceImplTest {
         when(changesetsService.getNewChangesets(any(Repository.class), any(RefChange.class))).thenReturn(Sets.newHashSet(changeset));
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, mockTagChange());
-        assertThat(errors).contains(new YaccError(YaccError.Type.COMMITTER_NAME,
-                "deadbeef: expected committer name 'John Smith' but found 'Incorrect Name'"));
-        assertThat(errors).contains(new YaccError(YaccError.Type.COMMITTER_EMAIL,
+        assertThat(errors).containsOnly(new YaccError(YaccError.Type.COMMITTER_NAME,
+                "deadbeef: expected committer name 'John Smith' but found 'Incorrect Name'"),
+                                        new YaccError(YaccError.Type.COMMITTER_EMAIL,
                 "deadbeef: expected committer email 'correct@email.com' but found 'wrong@email.com'"));
     }
 
@@ -453,7 +453,7 @@ public class YaccServiceImplTest {
         List<YaccError> errors = yaccService.checkRefChange(null, settings, refChange);
 
         assertThat(errors)
-                .containsExactly(new YaccError(YaccError.Type.BRANCH_NAME,
+                .containsOnly(new YaccError(YaccError.Type.BRANCH_NAME,
                         "Invalid branch name. 'master' does not match regex 'foo'"));
 
     }

--- a/src/test/java/ut/com/isroot/stash/plugin/checks/BranchNameCheckTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/checks/BranchNameCheckTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,7 +35,7 @@ public class BranchNameCheckTest {
         List<YaccError> errors = new BranchNameCheck(getSettings("foo"), "refs/heads/bar").check();
 
         assertThat(errors)
-                .containsExactly(new YaccError(YaccError.Type.BRANCH_NAME,
+                .containsOnly(new YaccError(YaccError.Type.BRANCH_NAME,
                         "Invalid branch name. 'bar' does not match regex 'foo'"));
     }
 

--- a/src/test/java/ut/com/isroot/stash/plugin/errors/YaccErrorBuilderTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/errors/YaccErrorBuilderTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/ut/com/isroot/stash/plugin/errors/YaccErrorTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/errors/YaccErrorTest.java
@@ -3,7 +3,7 @@ package ut.com.isroot.stash.plugin.errors;
 import com.isroot.stash.plugin.errors.YaccError;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sean Ford


### PR DESCRIPTION
Fest isn't maintained any more. This moves to assertj, which is (except for the package namespace) a drop-in replacement. (This isn't the latest assertj version; newer versions only support JDK7)

I also changed some of the asserts that were checking that the actual errors contained a certain string to validate that the actual error _only_ contained the expected error, without any unexpected ones. This is "more correct", and although it didn't show up any new issues it did find one issue with something I was working on locally.
