### PR TITLE
Added ability to validate branch name when the branch is created through the Stash UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ If present, pushes to branches that don't match this regex will be blocked.
 For example, `master|(?:(?:bugfix|hotfix|feature)/[A-Z]+-\d+-.+)` would enforce that pushes
 should be done to branches that follow the Stash Branching Model naming convention.
 
-*Note: This only affects pushes, not branches created through the Stash UI.*
-
 ####Exclude Merge Commits
 
 If enabled, merge commits will be excluded from commit requirements.

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>
@@ -219,8 +220,8 @@
     </build>
     <properties>
         <!-- When updating this, remember to update the marketplace version too -->
-        <stash.version>3.5.1</stash.version>
-        <stash.data.version>3.5.1</stash.data.version>
+        <stash.version>3.7.0</stash.version>
+        <stash.data.version>3.7.0</stash.data.version>
         <amps.version>5.1.11</amps.version>
         <plugin.testrunner.version>1.1.4</plugin.testrunner.version>
     </properties>

--- a/src/main/java/com/isroot/stash/plugin/YaccBranchCreationListener.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccBranchCreationListener.java
@@ -1,0 +1,77 @@
+package com.isroot.stash.plugin;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.atlassian.event.api.EventListener;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.stash.branch.BranchCreationRequestedEvent;
+import com.atlassian.stash.hook.repository.RepositoryHook;
+import com.atlassian.stash.hook.repository.RepositoryHookService;
+import com.atlassian.stash.i18n.I18nService;
+import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.setting.Settings;
+import com.atlassian.stash.user.Permission;
+import com.atlassian.stash.user.SecurityService;
+import com.atlassian.stash.util.UncheckedOperation;
+import com.isroot.stash.plugin.checks.BranchNameCheck;
+import com.isroot.stash.plugin.errors.YaccError;
+
+/**
+ * @author Hiroyuki Wada
+ */
+public class YaccBranchCreationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(YaccPreReceiveHook.class);
+
+    private final PluginSettingsFactory pluginSettingsFactory;
+    private final SecurityService securityService;
+    private final RepositoryHookService repositoryHookService;
+    private final I18nService i18nService;
+
+    public YaccBranchCreationListener(PluginSettingsFactory pluginSettingsFactory, SecurityService securityService,
+            RepositoryHookService repositoryHookService, I18nService i18nService) {
+        this.pluginSettingsFactory = pluginSettingsFactory;
+        this.securityService = securityService;
+        this.repositoryHookService = repositoryHookService;
+        this.i18nService = i18nService;
+    }
+
+    @EventListener
+    public void onBranchCreation(BranchCreationRequestedEvent event) {
+        final Repository repository = event.getRepository();
+
+        RepositoryHook hook = securityService.withPermission(Permission.REPO_ADMIN, "Get plugin configuration").call(
+                new UncheckedOperation<RepositoryHook>() {
+                    public RepositoryHook perform() {
+                        return repositoryHookService.getByKey(repository, "com.isroot.stash.plugin.yacc:yaccHook");
+                    }
+                });
+
+        Settings settings = null;
+
+        if (hook.isEnabled() && hook.isConfigured()) {
+            // Repository hook is configured and enabled.
+            // Repository hook overrides default pre-receive hook configuration
+            log.debug("PreReceiveRepositoryHook configured. Use repository configuration.");
+
+            settings = repositoryHookService.getSettings(repository, hook.getDetails().getKey());
+        } else {
+            // Repository hook not configured
+            log.debug("PreReceiveRepositoryHook not configured.  Use global configuration.");
+
+            settings = YaccUtils.buildYaccConfig(pluginSettingsFactory, repositoryHookService);
+        }
+
+        List<YaccError> errors = new BranchNameCheck(settings, event.getBranch().getId()).check();
+
+        if (!errors.isEmpty()) {
+            event.cancel(i18nService.getKeyedText("invalidBranchName", errors.get(0).getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/YaccPreReceiveHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccPreReceiveHook.java
@@ -1,6 +1,5 @@
 package com.isroot.stash.plugin;
 
-import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.stash.hook.HookResponse;
 import com.atlassian.stash.hook.PreReceiveHook;
@@ -18,8 +17,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Uldis Ansmits
@@ -65,40 +62,9 @@ public class YaccPreReceiveHook implements PreReceiveHook {
             // Repository hook not configured
             log.debug("PreReceiveRepositoryHook not configured. Run PreReceiveHook");
 
-            Settings storedConfig = buildYaccConfig(getSettingsMap());
+            Settings storedConfig = YaccUtils.buildYaccConfig(pluginSettingsFactory, repositoryHookService);
 
             return yaccHook.onReceive(new RepositoryHookContext(repository, storedConfig), refChanges, hookResponse);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> getSettingsMap() {
-        PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
-
-        Map<String, Object> settingsMap = (HashMap<String, Object>)pluginSettings.get(YaccConfigServlet.SETTINGS_MAP);
-
-        if(settingsMap == null) {
-            settingsMap = new HashMap<>();
-        }
-
-        return settingsMap;
-    }
-
-    private Settings buildYaccConfig(Map<String, Object> settingsMap) {
-        HashMap<String, Object> config = new HashMap<>();
-        for (String fieldName : settingsMap.keySet()) {
-            addFieldValueToPluginConfigMap(settingsMap, config, fieldName);
-        }
-
-        return repositoryHookService.createSettingsBuilder().addAll(config).build();
-    }
-
-    private void addFieldValueToPluginConfigMap(Map<String, Object> settingsMap, HashMap<String, Object> config, String fieldName) {
-        String value = (String) settingsMap.get(fieldName);
-        if (value != null && (value.equals("on") || value.equals("true"))) { // handle "on" value
-            config.put(fieldName, true);
-        } else if (value != null && !value.isEmpty()) {
-            config.put(fieldName, value);
         }
     }
 }

--- a/src/main/java/com/isroot/stash/plugin/YaccUtils.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccUtils.java
@@ -1,0 +1,48 @@
+package com.isroot.stash.plugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.stash.hook.repository.RepositoryHookService;
+import com.atlassian.stash.setting.Settings;
+
+/**
+ * @author Hiroyuki Wada
+ */
+public class YaccUtils {
+
+    public static Settings buildYaccConfig(PluginSettingsFactory pluginSettingsFactory,
+            RepositoryHookService repositoryHookService) {
+        Map<String, Object> settingsMap = getSettingsMap(pluginSettingsFactory);
+        HashMap<String, Object> config = new HashMap<>();
+        for (String fieldName : settingsMap.keySet()) {
+            addFieldValueToPluginConfigMap(settingsMap, config, fieldName);
+        }
+        return repositoryHookService.createSettingsBuilder().addAll(config).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getSettingsMap(PluginSettingsFactory pluginSettingsFactory) {
+        PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+
+        Map<String, Object> settingsMap = (HashMap<String, Object>) pluginSettings.get(YaccConfigServlet.SETTINGS_MAP);
+
+        if (settingsMap == null) {
+            settingsMap = new HashMap<>();
+        }
+
+        return settingsMap;
+    }
+
+    private static void addFieldValueToPluginConfigMap(Map<String, Object> settingsMap, HashMap<String, Object> config,
+            String fieldName) {
+        String value = (String) settingsMap.get(fieldName);
+        if (value != null && (value.equals("on") || value.equals("true"))) { // handle "on" value
+            config.put(fieldName, true);
+        } else if (value != null && !value.isEmpty()) {
+            config.put(fieldName, value);
+        }
+    }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -82,4 +82,7 @@
     <!-- Makes PluginSettingsFactory available to the plugin to allow the global settings to be set. -->
     <component-import key="pluginSettingsFactory" interface="com.atlassian.sal.api.pluginsettings.PluginSettingsFactory" />
 
+    <component key="YaccBranchCreationListener" class="com.isroot.stash.plugin.YaccBranchCreationListener"/>
+
+    <component-import key="i18nService" interface="com.atlassian.stash.i18n.I18nService"/>
 </atlassian-plugin>

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccBranchCreationListenerTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccBranchCreationListenerTest.java
@@ -1,0 +1,142 @@
+package ut.com.isroot.stash.plugin;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.stash.branch.BranchCreationRequestedEvent;
+import com.atlassian.stash.hook.repository.RepositoryHook;
+import com.atlassian.stash.hook.repository.RepositoryHookDetails;
+import com.atlassian.stash.hook.repository.RepositoryHookService;
+import com.atlassian.stash.i18n.I18nService;
+import com.atlassian.stash.i18n.KeyedMessage;
+import com.atlassian.stash.repository.Branch;
+import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.setting.Settings;
+import com.atlassian.stash.setting.SettingsBuilder;
+import com.atlassian.stash.user.EscalatedSecurityContext;
+import com.atlassian.stash.user.Permission;
+import com.atlassian.stash.user.SecurityService;
+import com.atlassian.stash.util.CancelState;
+import com.atlassian.stash.util.UncheckedOperation;
+import com.isroot.stash.plugin.YaccBranchCreationListener;
+
+/**
+ * @author Hiroyuki Wada
+ * 
+ */
+public class YaccBranchCreationListenerTest {
+    @Mock private RepositoryHookService repositoryHookService;
+    @Mock private RepositoryHook repositoryHook;
+    @Mock private RepositoryHookDetails repositoryHookDetails;
+    @Mock private Repository repository;
+    @Mock private Branch branch;
+    @Mock private CancelState cancelState;
+    @Mock private SecurityService securityService;
+    @Mock private EscalatedSecurityContext escalatedSecurityContext;
+    @Mock private PluginSettingsFactory pluginSettingsFactory;
+    @Mock private PluginSettings pluginSettings;
+    @Mock private SettingsBuilder settingsBuilder;
+    @Mock private Settings settings;
+    @Mock private I18nService i18nService;
+    @Mock private BranchCreationRequestedEvent event;
+    @Mock private KeyedMessage message;
+    private Map<String, Object> settingsMap = new HashMap<String, Object>();
+
+    private YaccBranchCreationListener yaccBranchCreationListener;
+
+
+    @Before
+    public void setup() throws Throwable {
+        MockitoAnnotations.initMocks(this);
+
+        yaccBranchCreationListener = new YaccBranchCreationListener(
+                pluginSettingsFactory, securityService, repositoryHookService, i18nService);
+
+        //mock hook retrieval
+        when(securityService.withPermission(Permission.REPO_ADMIN, "Get plugin configuration"))
+                .thenReturn(escalatedSecurityContext);
+        when(escalatedSecurityContext.call(any(UncheckedOperation.class))).thenReturn(repositoryHook);
+    }
+
+    @Test
+    public void testOnBranchCreation_errorIfBranchNameDoesNotMatchRegex_repositoryHookConfigured(){
+        when(repositoryHook.isConfigured()).thenReturn(true);
+        when(repositoryHook.isEnabled()).thenReturn(true);
+        when(repositoryHook.getDetails()).thenReturn(repositoryHookDetails);
+        when(repositoryHookDetails.getKey()).thenReturn(anyString());
+        when(repositoryHookService.getSettings(repository, anyString())).thenReturn(settings);
+
+        when(event.getBranch()).thenReturn(branch);
+        when(branch.getId()).thenReturn("refs/heads/bar");
+        when(settings.getString("branchNameRegex")).thenReturn("foo");
+        when(i18nService.getKeyedText(anyString(), anyString())).thenReturn(message);
+
+        yaccBranchCreationListener.onBranchCreation(event);
+
+        verify(event, times(1)).cancel(message);
+    }
+
+    @Test
+    public void testOnBranchCreation_noErrorIfBranchNameDoesNotMatchRegex_repositoryHookConfigured(){
+        when(repositoryHook.isConfigured()).thenReturn(true);
+        when(repositoryHook.isEnabled()).thenReturn(true);
+        when(repositoryHook.getDetails()).thenReturn(repositoryHookDetails);
+        when(repositoryHookDetails.getKey()).thenReturn(anyString());
+        when(repositoryHookService.getSettings(repository, anyString())).thenReturn(settings);
+
+        when(event.getBranch()).thenReturn(branch);
+        when(branch.getId()).thenReturn("refs/heads/foo");
+        when(settings.getString("branchNameRegex")).thenReturn("foo");
+        when(i18nService.getKeyedText(anyString(), anyString())).thenReturn(message);
+
+        yaccBranchCreationListener.onBranchCreation(event);
+
+        verify(event, never()).cancel(message);
+    }
+
+    @Test
+    public void testOnBranchCreation_errorIfBranchNameDoesNotMatchRegex_globalConfigured(){
+        when(pluginSettingsFactory.createGlobalSettings()).thenReturn(pluginSettings);
+        when(pluginSettings.get(anyString())).thenReturn(settingsMap);
+        when(repositoryHookService.createSettingsBuilder()).thenReturn(settingsBuilder);
+        when(settingsBuilder.addAll(anyMap())).thenReturn(settingsBuilder);
+        when(settingsBuilder.build()).thenReturn(settings);
+
+        when(event.getBranch()).thenReturn(branch);
+        when(branch.getId()).thenReturn("refs/heads/bar");
+        when(settings.getString("branchNameRegex")).thenReturn("foo");
+        when(i18nService.getKeyedText(anyString(), anyString())).thenReturn(message);
+
+        yaccBranchCreationListener.onBranchCreation(event);
+
+        verify(event, times(1)).cancel(message);
+    }
+
+    @Test
+    public void testOnBranchCreation_noErrorIfBranchNameDoesNotMatchRegex_globalConfigured(){
+        when(pluginSettingsFactory.createGlobalSettings()).thenReturn(pluginSettings);
+        when(pluginSettings.get(anyString())).thenReturn(settingsMap);
+        when(repositoryHookService.createSettingsBuilder()).thenReturn(settingsBuilder);
+        when(settingsBuilder.addAll(anyMap())).thenReturn(settingsBuilder);
+        when(settingsBuilder.build()).thenReturn(settings);
+
+        when(event.getBranch()).thenReturn(branch);
+        when(branch.getId()).thenReturn("refs/heads/foo");
+        when(settings.getString("branchNameRegex")).thenReturn("foo");
+        when(i18nService.getKeyedText(anyString(), anyString())).thenReturn(message);
+
+        yaccBranchCreationListener.onBranchCreation(event);
+
+        verify(event, never()).cancel(message);
+    }
+}


### PR DESCRIPTION
Currently, 'Branch Name Regex' setting doesn't affect when the branch is created through the Stash UI.
As it is mentioned in issue #31, stash now has an event that is fired before the branch is created in the UI. So I added this event listener that validate branch name.

Note: It requires stash 3.7.0.
