### PR TITLE
Set line.separator for unit test on Windows

### DIFF
--- a/src/test/java/ut/com/isroot/stash/plugin/ConfigValidatorTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/ConfigValidatorTest.java
@@ -29,6 +29,7 @@ public class ConfigValidatorTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
+        System.setProperty("line.separator", "\n");
 
         configValidator = new ConfigValidator(jiraService);
     }


### PR DESCRIPTION
I noticed that 'ConfigValidatorTest' fails on Windows because of difference in line separator.
