### PR TITLE
Skip branch name checks for existing branches.

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -2,6 +2,7 @@ package com.isroot.stash.plugin;
 
 import com.atlassian.bitbucket.auth.AuthenticationContext;
 import com.atlassian.bitbucket.repository.RefChange;
+import com.atlassian.bitbucket.repository.RefChangeType;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.user.ApplicationUser;
@@ -46,7 +47,9 @@ public class YaccServiceImpl implements YaccService {
 
         List<YaccError> errors = Lists.newArrayList();
 
-        errors.addAll(new BranchNameCheck(settings, refChange.getRefId()).check());
+        if (refChange.getType() == RefChangeType.ADD) {
+            errors.addAll(new BranchNameCheck(settings, refChange.getRefId()).check());
+        }
 
         Set<YaccCommit> commits = commitsService.getNewCommits(repository, refChange);
 

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -453,10 +453,10 @@ public class YaccServiceImplTest {
     }
 
     @Test
-    public void testCheckRefChange_branchNameCheckApplied() {
+    public void testCheckRefAdd_branchNameCheckApplied() {
         when(settings.getString("branchNameRegex")).thenReturn("foo");
 
-        RefChange refChange = mockRefChange();
+        RefChange refChange = mockRefAdd();
 
         List<YaccError> errors = yaccService.checkRefChange(null, settings, refChange);
 
@@ -466,6 +466,17 @@ public class YaccServiceImplTest {
 
     }
 
+    @Test
+    public void testCheckRefChange_branchNameCheckApplied() {
+        when(settings.getString("branchNameRegex")).thenReturn("foo");
+
+        RefChange refChange = mockRefChange();
+
+        List<YaccError> errors = yaccService.checkRefChange(null, settings, refChange);
+
+        assertThat(errors).isEmpty();
+    }
+
     private YaccCommit mockCommit() {
         YaccCommit commit = mock(YaccCommit.class, RETURNS_DEEP_STUBS);
         when(commit.getCommitter().getName()).thenReturn("John Smith");
@@ -473,6 +484,15 @@ public class YaccServiceImplTest {
         when(commit.getId()).thenReturn("deadbeef");
         when(commit.getParentCount()).thenReturn(1);
         return commit;
+    }
+
+    private RefChange mockRefAdd() {
+        RefChange refChange = mock(RefChange.class);
+        when(refChange.getFromHash()).thenReturn("0000000000000000000000000000000000000000");
+        when(refChange.getToHash()).thenReturn("35d938b060bb361503e021f228e43351f1a71551");
+        when(refChange.getRefId()).thenReturn("refs/heads/master");
+        when(refChange.getType()).thenReturn(RefChangeType.ADD);
+        return refChange;
     }
 
     private RefChange mockRefChange() {


### PR DESCRIPTION
This change makes YACC skip branch name checks for existing branches.  The use case for this is an organization that wants to enforce a naming convention for new branches, while allowing its many existing branches to be usable.  The expectation is that existing non-conforming branches will eventually go away as they are merged and deleted.