### PR TITLE
[Issue 150] Updated the way of collecting commits that should be checked.

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/YaccCommit.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccCommit.java
@@ -70,4 +70,14 @@ public class YaccCommit {
     public boolean isMerge() {
         return isMerge;
     }
+
+    @Override
+    public boolean equals(final Object other) {
+        return other instanceof YaccCommit && ((YaccCommit) other).id.equals(id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
 }

--- a/src/main/java/com/isroot/stash/plugin/commits/CommitsServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/commits/CommitsServiceImpl.java
@@ -63,15 +63,26 @@ public class CommitsServiceImpl implements CommitsService {
                 yaccCommits.add(commit);
             }
         } else {
-            GitRevListBuilder revListBuilder = getGitScmCommandBuilder(repository).revList()
+            GitRevListBuilder currentRevListBuilder = getGitScmCommandBuilder(repository).revList()
                     .format(RevListOutputHandler.FORMAT)
-                    .revs(refChange.getToHash(), "--not", "--all");
+                    .rev(refChange.getToHash());
 
-            List<YaccCommit> found = revListBuilder.build(new RevListOutputHandler())
+            List<YaccCommit> currentFound = currentRevListBuilder.build(new RevListOutputHandler())
                     .call();
 
-            if (found != null) {
-                yaccCommits.addAll(found);
+            GitRevListBuilder allRevListBuilder = getGitScmCommandBuilder(repository).revList()
+                    .format(RevListOutputHandler.FORMAT)
+                    .all(true);
+
+            List<YaccCommit> allFound = allRevListBuilder.build(new RevListOutputHandler())
+                    .call();
+
+            if (currentFound != null) {
+                yaccCommits.addAll(currentFound);
+            }
+
+            if (allFound != null) {
+                yaccCommits.removeAll(allFound);
             }
         }
 


### PR DESCRIPTION
I see now that You try to build a git rev-list command like this:

"git rev-list <new hash> --not --all" - to get every commit that is reachable from the newly pushed HEAD but not from any refs.

However, I think that passing "--not" and "--all" to [this method](https://developer.atlassian.com/static/javadoc/bitbucket-server/4.0.7/git-api/reference/com/atlassian/bitbucket/scm/git/command/revlist/GitRevListBuilder.html#revs(java.lang.String,%20java.lang.String...)) is not too robust, because this API is expected to receive revisions given by ref names or commit hashes. In my opinion, passing switches to them may or may not work, because this depends on the implementation details of the Bitbucket Git library.

Because of that, I modified the solution to use APIs as they were intended to use. (Unfortunately, this solution is surely suboptimal, but it should work as expected regardless of the implementation details.)

In addition, I implemented the equals and hashCode methods for the YaccCommit class, because they are used with collections (particularly HashSet).

Unfortunately, I cannot build and test my changes. Could you please test them, and merge them if You find them good enough to be included?

Thanks in advance. 

