### PR TITLE
Use TImeLimitedMatcher for matching regular expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - openjdk8
 before_install:
-  - curl https://packages.atlassian.com/list/atlassian-sdk-deb/deb-archive/atlassian-plugin-sdk_6.3.7_all.deb -O
+  - curl https://packages.atlassian.com/list/atlassian-sdk-deb/deb-archive/atlassian-plugin-sdk_6.3.7_all.deb -L -O
   - sudo dpkg -i ./atlassian-plugin-sdk_6.3.7_all.deb
 install:
   - atlas-mvn -q install -DskipTests=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8 
+  - openjdk8
 before_install:
   - curl https://packages.atlassian.com/list/atlassian-sdk-deb/deb-archive/atlassian-plugin-sdk_6.3.7_all.deb -O
   - sudo dpkg -i ./atlassian-plugin-sdk_6.3.7_all.deb

--- a/src/main/java/com/isroot/stash/plugin/TimeLimitedMatcherFactory.java
+++ b/src/main/java/com/isroot/stash/plugin/TimeLimitedMatcherFactory.java
@@ -1,0 +1,146 @@
+package com.isroot.stash.plugin;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A factory class used to generate Matcher instances that will throw if in use after their
+ * timeout.
+ */
+public abstract class TimeLimitedMatcherFactory {
+
+    // If a regular expression requires more than a couple of seconds
+    // to complete, then it has no place in polite society.
+    private static final long RE_TIMEOUT = 2000L;
+
+    /**
+     * Generate a Matcher instance that will throw if used or still in use more than
+     * timeoutInMilliseconds after its instantiation.
+     * <p>
+     * Use the instance immediately and then discard it.
+     *
+     * @param pattern               The Pattern instance.
+     * @param charSequence          The CharSequence to operate on.
+     * @param timeoutInMilliseconds Throw after this timeout is reached.
+     */
+    public static Matcher matcher(
+            Pattern pattern,
+            CharSequence charSequence,
+            long timeoutInMilliseconds
+    ) {
+        // Substitute in our exploding CharSequence implementation.
+        if (!(charSequence instanceof TimeLimitedCharSequence)) {
+            charSequence = new TimeLimitedCharSequence(
+                    charSequence,
+                    timeoutInMilliseconds,
+                    pattern,
+                    charSequence
+            );
+        }
+
+        return pattern.matcher(charSequence);
+    }
+
+    /**
+     * Generate a Matcher instance that will throw if used or still in use more than 2 seconds after
+     * its instantiation.
+     * <p>
+     * Use the instance immediately and then discard it.
+     *
+     * @param pattern      The Pattern instance.
+     * @param charSequence The CharSequence to operate on.
+     */
+    public static Matcher matcher(
+            Pattern pattern,
+            CharSequence charSequence
+    ) {
+        return matcher(pattern, charSequence, RE_TIMEOUT);
+    }
+
+    /**
+     * An exception to indicate that a regular expression operation timed out.
+     */
+    public static class RegExpTimeoutException extends RuntimeException {
+
+        public RegExpTimeoutException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * A CharSequence implementation that throws when charAt() is called after a given timeout.
+     * <p>
+     * Since charAt() is invoked frequently in regular expression operations on a string, this gives a
+     * way to abort long-running regular expression operations.
+     */
+    private static class TimeLimitedCharSequence implements CharSequence {
+
+        private final CharSequence inner;
+        private final long timeoutInMilliseconds;
+        private final long timeoutAfterTimestamp;
+        private final Pattern pattern;
+        private final CharSequence originalCharSequence;
+
+        /**
+         * Default constructor.
+         *
+         * @param inner                 The CharSequence to wrap. This may be a subsequence of the
+         *                              original.
+         * @param timeoutInMilliseconds How long before calls to charAt() throw.
+         * @param pattern               The Pattern instance; only used for logging purposes.
+         * @param originalCharSequence  originalCharSequence The original sequence, used for logging
+         *                              purposes.
+         */
+        public TimeLimitedCharSequence(
+                CharSequence inner,
+                long timeoutInMilliseconds,
+                Pattern pattern,
+                CharSequence originalCharSequence
+        ) {
+            super();
+            this.inner = inner;
+            this.timeoutInMilliseconds = timeoutInMilliseconds;
+            // Carry out this calculation here, once, rather than every time
+            // charAt() is invoked. Little optimizations make the world turn.
+            timeoutAfterTimestamp = System.currentTimeMillis() + timeoutInMilliseconds;
+            this.pattern = pattern;
+            this.originalCharSequence = originalCharSequence;
+        }
+
+        public char charAt(int index) {
+            // This is an unavoidable slowdown, but what can you do?
+            if (System.currentTimeMillis() > timeoutAfterTimestamp) {
+                // Note that we add the original charsequence to the exception
+                // message. This condition can be met on a subsequence of the
+                // original sequence, and the subsequence string is rarely
+                // anywhere near as helpful.
+                throw new RegExpTimeoutException(
+                        "Regular expression timeout after " + timeoutInMilliseconds
+                                + "ms for [ " + pattern.pattern() + " ] operating on [ "
+                                + originalCharSequence + " ]"
+                );
+            }
+            return inner.charAt(index);
+        }
+
+        public int length() {
+            return inner.length();
+        }
+
+        public CharSequence subSequence(int start, int end) {
+            // Ensure that any subsequence generated during a regular expression
+            // operation is still going to explode on time.
+            return new TimeLimitedCharSequence(
+                    inner.subSequence(start, end),
+                    timeoutAfterTimestamp - System.currentTimeMillis(),
+                    pattern,
+                    originalCharSequence
+            );
+        }
+
+        @Override
+        public String toString() {
+            return inner.toString();
+        }
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/TimeLimitedMatcherFactory.java
+++ b/src/main/java/com/isroot/stash/plugin/TimeLimitedMatcherFactory.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 /**
  * A factory class used to generate Matcher instances that will throw if in use after their
  * timeout.
+ * Source blog post: https://www.exratione.com/2017/06/preventing-unbounded-regular-expression-operations-in-java/
  */
 public abstract class TimeLimitedMatcherFactory {
 

--- a/src/main/java/com/isroot/stash/plugin/YaccHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccHook.java
@@ -66,7 +66,16 @@ public class YaccHook implements PreRepositoryHook {
             @Nonnull RepositoryPushHookRequest repositoryPushHookRequest) {
         final Settings settings = context.getSettings();
 
-        return yaccService.check(context, repositoryPushHookRequest, settings);
+        RepositoryHookResult result;
+        try {
+            result = yaccService.check(context, repositoryPushHookRequest, settings);
+        } catch (TimeLimitedMatcherFactory.RegExpTimeoutException e) {
+            log.error("Regex timeout for {} / {}", repositoryPushHookRequest.getRepository().getProject().getName(), repositoryPushHookRequest.getRepository().getName());
+            log.error("Regex timeout exceeded", e);
+            result = RepositoryHookResult.rejected("Regex timeout exceeded", "The timeout for evaluating regular expression has been exceeded");
+        }
+
+        return result;
     }
 
     static RepositoryHookResult handleBranchCreation(@Nonnull Settings settings,

--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -202,7 +202,7 @@ public class YaccServiceImpl implements YaccService {
 
         if (excludeRegex != null && !excludeRegex.isEmpty()) {
             Pattern pattern = Pattern.compile(excludeRegex);
-            Matcher matcher = pattern.matcher(commit.getMessage());
+            Matcher matcher = TimeLimitedMatcherFactory.matcher(pattern, commit.getMessage());
             if (matcher.find()) {
                 log.debug("commit excluded because excludeByRegex={} matches", excludeRegex);
                 return true;
@@ -221,7 +221,7 @@ public class YaccServiceImpl implements YaccService {
 
         if (excludeBranchRegex != null && !excludeBranchRegex.isEmpty()) {
             Pattern pattern = Pattern.compile(excludeBranchRegex);
-            Matcher matcher = pattern.matcher(branchName);
+            Matcher matcher = TimeLimitedMatcherFactory.matcher(pattern, branchName);
             if (matcher.matches()) {
                 log.debug("branch is excluded");
                 return true;
@@ -237,7 +237,7 @@ public class YaccServiceImpl implements YaccService {
         String regex = settings.getString("commitMessageRegex");
         if (!isNullOrEmpty(regex)) {
             Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
-            Matcher matcher = pattern.matcher(commit.getMessage());
+            Matcher matcher = TimeLimitedMatcherFactory.matcher(pattern, commit.getMessage());
             if (!matcher.matches()) {
                 errors.add(new YaccError(YaccError.Type.COMMIT_REGEX,
                         "commit message doesn't match regex: " + regex));
@@ -252,7 +252,7 @@ public class YaccServiceImpl implements YaccService {
         String regex = settings.getString("committerEmailRegex");
         if (!isNullOrEmpty(regex)) {
             Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
-            Matcher matcher = pattern.matcher(commit.getCommitter().getEmailAddress().toLowerCase());
+            Matcher matcher = TimeLimitedMatcherFactory.matcher(pattern, commit.getCommitter().getEmailAddress().toLowerCase());
             if (!matcher.matches()) {
                 errors.add(new YaccError(YaccError.Type.COMMITTER_EMAIL_REGEX,
                         String.format("committer email regex '%s' does not match user email '%s'", regex,
@@ -271,7 +271,7 @@ public class YaccServiceImpl implements YaccService {
         String regex = settings.getString("commitMessageRegex");
         if (!isNullOrEmpty(regex)) {
             Pattern pattern = Pattern.compile(regex);
-            Matcher matcher = pattern.matcher(message);
+            Matcher matcher =  TimeLimitedMatcherFactory.matcher(pattern, message);
             if (matcher.matches() && matcher.groupCount() > 0) {
                 message = matcher.group(1);
             }

--- a/src/test/java/ut/com/isroot/stash/plugin/ConfigValidatorTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/ConfigValidatorTest.java
@@ -102,8 +102,7 @@ public class ConfigValidatorTest {
 
         verify(settings).getString("excludeByRegex");
         verify(settingsValidationErrors).addFieldError("excludeByRegex", "Invalid Regex: Unclosed group near index 2\n" +
-                "^(\n" +
-                "  ^");
+                "^(");
     }
 
     @Test
@@ -133,8 +132,7 @@ public class ConfigValidatorTest {
 
         verify(settings).getString("excludeBranchRegex");
         verify(settingsValidationErrors).addFieldError("excludeBranchRegex", "Invalid Regex: Unclosed group near index 2\n" +
-                "^(\n" +
-                "  ^");
+                "^(");
     }
 
     @Test

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -1,6 +1,7 @@
 package ut.com.isroot.stash.plugin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,7 @@ import com.atlassian.bitbucket.user.UserType;
 import com.google.common.collect.Lists;
 import com.isroot.stash.plugin.IssueKey;
 import com.isroot.stash.plugin.JiraService;
+import com.isroot.stash.plugin.TimeLimitedMatcherFactory;
 import com.isroot.stash.plugin.YaccCommit;
 import com.isroot.stash.plugin.YaccService;
 import com.isroot.stash.plugin.YaccServiceImpl;
@@ -69,6 +71,24 @@ public class YaccServiceImplTest {
 
         when(stashAuthenticationContext.getCurrentUser()).thenReturn(stashUser);
     }
+
+    @Test
+    public void testCheckCommit_rejectCatastrophicBacktrack() {
+        settings.setCommitMessageRegex("^(a+)+$");
+
+        YaccCommit commit = mockCommit();
+        when(commit.getMessage())
+                .thenReturn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX");
+
+        // commit should be rejected because regex is causing catastrophic backtrack and timeout is expired
+        try {
+            yaccService.checkCommit(settings, commit, null);
+            failBecauseExceptionWasNotThrown(TimeLimitedMatcherFactory.RegExpTimeoutException.class);
+        } catch (Exception ex) {
+            assertThat(ex).isInstanceOf(TimeLimitedMatcherFactory.RegExpTimeoutException.class);
+        }
+    }
+
 
     @Test
     public void testCheckCommit_requireMatchingAuthorName_rejectOnMismatch() throws Exception {

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccServiceImplTest.java
@@ -74,7 +74,7 @@ public class YaccServiceImplTest {
 
     @Test
     public void testCheckCommit_rejectCatastrophicBacktrack() {
-        settings.setCommitMessageRegex("^(a+)+$");
+        settings.setCommitMessageRegex("(((a+)+)+)+");
 
         YaccCommit commit = mockCommit();
         when(commit.getMessage())


### PR DESCRIPTION
We were suffering severe high CPU usage issues from time to time in our 2 nodes Bitbucket server. After some investigation, we detected that threads matching regular expressions from yacc plugin were causing the high CPU usage. This lead us to the RegEx DoS https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS problem, which can be reproduced easily by using an evil regex and a specially crafter commit message.

In order to avoid DoS with badly crafted regular expressions, use TImeLimitedMatcher from https://www.exratione.com/2017/06/preventing-unbounded-regular-expression-operations-in-java/ to set matching timeout to 2 seconds (default). If the match fails to finish before the timeout, the commit will be rejected and an error message logged.