### PR TITLE
Run YACC with Bitbucket WEB editor. Impersonate a user when getting JIRA issues.

### DIFF
--- a/src/main/java/com/isroot/stash/plugin/ImpersonationService.java
+++ b/src/main/java/com/isroot/stash/plugin/ImpersonationService.java
@@ -1,0 +1,40 @@
+package com.isroot.stash.plugin;
+
+import com.atlassian.bitbucket.hook.repository.RepositoryHookService;
+import com.atlassian.bitbucket.setting.Settings;
+import com.atlassian.bitbucket.user.SecurityService;
+import com.atlassian.bitbucket.user.UserService;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class ImpersonationService {
+    private final UserService userService;
+    private final SecurityService securityService;
+    private final PluginSettingsFactory pluginSettingsFactory;
+    private final RepositoryHookService repositoryHookService;
+
+    public ImpersonationService(
+        UserService userService,
+        SecurityService securityService,
+        PluginSettingsFactory pluginSettingsFactory,
+        RepositoryHookService repositoryHookService
+    ) {
+        this.userService = userService;
+        this.securityService = securityService;
+        this.pluginSettingsFactory = pluginSettingsFactory;
+        this.repositoryHookService = repositoryHookService;
+    }
+
+    public  <T> T runImpersonating(Supplier<T> handler) {
+        Settings settings = YaccUtils.buildYaccConfig(pluginSettingsFactory, repositoryHookService);
+        if (settings.getBoolean("overrideJiraUserEnabled", false) && StringUtils.isNotEmpty(settings.getString("overrideJiraUser"))) {
+            return Optional.ofNullable(userService.getUserByName(settings.getString("overrideJiraUser"))).map(applicationUser ->
+                securityService.impersonating(applicationUser, "YACC Hook").call(handler::get)
+            ).orElseGet(handler);
+        }
+        return handler.get();
+    }
+}

--- a/src/main/java/com/isroot/stash/plugin/YaccConfigServlet.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccConfigServlet.java
@@ -4,6 +4,7 @@ import com.atlassian.bitbucket.hook.repository.RepositoryHookService;
 import com.atlassian.bitbucket.nav.NavBuilder;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.setting.SettingsValidationErrors;
+import com.atlassian.bitbucket.user.UserService;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.soy.renderer.SoyException;
@@ -45,14 +46,15 @@ public class YaccConfigServlet extends HttpServlet {
                              PluginSettingsFactory pluginSettingsFactory,
                              JiraService jiraService,
                              RepositoryHookService repositoryHookService,
-                             NavBuilder navBuilder) {
+                             NavBuilder navBuilder,
+                             UserService userService) {
         this.soyTemplateRenderer = soyTemplateRenderer;
         this.navBuilder = navBuilder;
         this.repositoryHookService = repositoryHookService;
 
         pluginSettings = pluginSettingsFactory.createGlobalSettings();
 
-        configValidator = new ConfigValidator(jiraService);
+        configValidator = new ConfigValidator(jiraService, userService);
 
         fields = new HashMap<>();
         fieldErrors = new HashMap<>();

--- a/src/main/java/com/isroot/stash/plugin/YaccGlobalHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccGlobalHook.java
@@ -8,7 +8,6 @@ import com.atlassian.bitbucket.hook.repository.RepositoryHookRequest;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookResult;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookService;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookTrigger;
-import com.atlassian.bitbucket.hook.repository.RepositoryPushHookRequest;
 import com.atlassian.bitbucket.hook.repository.StandardRepositoryHookTrigger;
 import com.atlassian.bitbucket.permission.Permission;
 import com.atlassian.bitbucket.repository.Repository;
@@ -90,7 +89,7 @@ public class YaccGlobalHook implements PreRepositoryHook {
         final RepositoryHookTrigger trigger = request.getTrigger();
 
         if (trigger == StandardRepositoryHookTrigger.REPO_PUSH) {
-            return yaccService.check(context, (RepositoryPushHookRequest) request, config);
+            return yaccService.check(context, request, config);
         } else if (trigger == StandardRepositoryHookTrigger.BRANCH_CREATE
                 && request instanceof BranchCreationHookRequest) {
 

--- a/src/main/java/com/isroot/stash/plugin/YaccHook.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccHook.java
@@ -6,7 +6,6 @@ import com.atlassian.bitbucket.hook.repository.PreRepositoryHookContext;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookRequest;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookResult;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookTrigger;
-import com.atlassian.bitbucket.hook.repository.RepositoryPushHookRequest;
 import com.atlassian.bitbucket.hook.repository.StandardRepositoryHookTrigger;
 import com.atlassian.bitbucket.repository.Branch;
 import com.atlassian.bitbucket.setting.Settings;
@@ -43,8 +42,8 @@ public class YaccHook implements PreRepositoryHook {
 
         final RepositoryHookTrigger trigger = repositoryHookRequest.getTrigger();
 
-        if (trigger == StandardRepositoryHookTrigger.REPO_PUSH) {
-            return handleRepositoryPush(context, (RepositoryPushHookRequest) repositoryHookRequest);
+        if (trigger == StandardRepositoryHookTrigger.REPO_PUSH || trigger == StandardRepositoryHookTrigger.FILE_EDIT) {
+            return handleRepositoryPush(context, repositoryHookRequest);
         } else if (trigger == StandardRepositoryHookTrigger.BRANCH_CREATE
                 && repositoryHookRequest instanceof BranchCreationHookRequest) {
 
@@ -63,14 +62,14 @@ public class YaccHook implements PreRepositoryHook {
 
     private RepositoryHookResult handleRepositoryPush(
             @Nonnull PreRepositoryHookContext context,
-            @Nonnull RepositoryPushHookRequest repositoryPushHookRequest) {
+            @Nonnull RepositoryHookRequest repositoryHookRequest) {
         final Settings settings = context.getSettings();
 
         RepositoryHookResult result;
         try {
-            result = yaccService.check(context, repositoryPushHookRequest, settings);
+            result = yaccService.check(context, repositoryHookRequest, settings);
         } catch (TimeLimitedMatcherFactory.RegExpTimeoutException e) {
-            log.error("Regex timeout for {} / {}", repositoryPushHookRequest.getRepository().getProject().getName(), repositoryPushHookRequest.getRepository().getName());
+            log.error("Regex timeout for {} / {}", repositoryHookRequest.getRepository().getProject().getName(), repositoryHookRequest.getRepository().getName());
             log.error("Regex timeout exceeded", e);
             result = RepositoryHookResult.rejected("Regex timeout exceeded", "The timeout for evaluating regular expression has been exceeded");
         }

--- a/src/main/java/com/isroot/stash/plugin/YaccService.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccService.java
@@ -1,8 +1,8 @@
 package com.isroot.stash.plugin;
 
 import com.atlassian.bitbucket.hook.repository.PreRepositoryHookContext;
+import com.atlassian.bitbucket.hook.repository.RepositoryHookRequest;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookResult;
-import com.atlassian.bitbucket.hook.repository.RepositoryPushHookRequest;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.setting.Settings;
@@ -16,7 +16,7 @@ import java.util.List;
  */
 public interface YaccService {
     RepositoryHookResult check(PreRepositoryHookContext context,
-            RepositoryPushHookRequest repositoryPushHookRequest, Settings settings);
+                               RepositoryHookRequest repositoryHookRequest, Settings settings);
 
     List<YaccError> checkRefChange(Repository repository, Settings settings, RefChange refChange);
 

--- a/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
+++ b/src/main/java/com/isroot/stash/plugin/YaccServiceImpl.java
@@ -3,8 +3,8 @@ package com.isroot.stash.plugin;
 import com.atlassian.bitbucket.auth.AuthenticationContext;
 import com.atlassian.bitbucket.hook.repository.PreRepositoryHookContext;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookCommitFilter;
+import com.atlassian.bitbucket.hook.repository.RepositoryHookRequest;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookResult;
-import com.atlassian.bitbucket.hook.repository.RepositoryPushHookRequest;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.RefChangeType;
 import com.atlassian.bitbucket.repository.Repository;
@@ -55,13 +55,13 @@ public class YaccServiceImpl implements YaccService {
 
     @Override
     public RepositoryHookResult check(PreRepositoryHookContext context,
-            RepositoryPushHookRequest repositoryPushHookRequest, Settings settings) {
+                RepositoryHookRequest repositoryHookRequest, Settings settings) {
         log.debug("YaccHook preUpdate, registering commit callback. settings={}", settings);
 
-        Repository repository = repositoryPushHookRequest.getRepository();
+        Repository repository = repositoryHookRequest.getRepository();
 
         List<YaccError> errors = checkRefs(repository, settings,
-                repositoryPushHookRequest.getRefChanges());
+                repositoryHookRequest.getRefChanges());
         if (!errors.isEmpty()) {
             YaccErrorBuilder errorBuilder = new YaccErrorBuilder(settings);
             String message = errorBuilder.getErrorMessage(errors);

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -12,22 +12,22 @@
 
     <!-- add our i18n resource -->
     <resource type="i18n" name="i18n" location="yacc"/>
-    
+
     <!-- add our web resources -->
     <web-resource key="yacc-resources" name="yacc Web Resources">
         <dependency>com.atlassian.auiplugin:ajs</dependency>
-        
+
         <resource type="download" name="yacc.css" location="/css/yacc.css"/>
         <resource type="download" name="yacc.js" location="/js/yacc.js"/>
         <resource type="download" name="images/" location="/images"/>
 
         <context>yacc</context>
     </web-resource>
-    
+
     <!-- import from the product container -->
     <component-import key="applicationProperties" interface="com.atlassian.sal.api.ApplicationProperties" />
 
-	<component-import key="applicationLinkService" interface="com.atlassian.applinks.api.ApplicationLinkService" />
+    <component-import key="applicationLinkService" interface="com.atlassian.applinks.api.ApplicationLinkService"/>
 
     <component-import key="scmService" interface="com.atlassian.bitbucket.scm.ScmService"/>
 
@@ -42,18 +42,31 @@
         <interface>com.isroot.stash.plugin.YaccService</interface>
     </component>
 
-	<repository-hook key="yaccHook" name="Yet Another Commit Checker"  class="com.isroot.stash.plugin.YaccHook">
-		<description>Yet Another Commit Checker pre-receive hook.</description>
-		<config-form name="Yacc Hook Config" key="yaccHook-config">
-			<view>com.atlassian.stash.repository.hook.ref.formContents</view>
-			<directory location="/static/" />
-		</config-form>
-		<validator>com.isroot.stash.plugin.ConfigValidator</validator>
+    <component key="impersonizationService" class="com.isroot.stash.plugin.ImpersonationService" public="true">
+        <interface>com.isroot.stash.plugin.ImpersonationService</interface>
+    </component>
+
+    <repository-hook key="yaccHook" name="Yet Another Commit Checker" class="com.isroot.stash.plugin.YaccHook">
+        <description>Yet Another Commit Checker pre-receive hook.</description>
+        <config-form name="Yacc Hook Config" key="yaccHook-config">
+            <view>com.atlassian.stash.repository.hook.ref.formContents</view>
+            <directory location="/static/"/>
+        </config-form>
+        <validator>com.isroot.stash.plugin.ConfigValidator</validator>
         <scopes>
             <scope>project</scope>
             <scope>repository</scope>
         </scopes>
-	</repository-hook>
+    </repository-hook>
+
+    <web-item name="YACC global settings" i18n-name-key="yacc.settings.item.name"
+              key="yacc-settings-item" section="atl.admin/admin-plugins-section" weight="1000">
+        <description key="yacc-settings-item-description">
+            YACC Global Settings Item Plugin
+        </description>
+        <label key="yacc-settings-item.label"/>
+        <link linkId="yacc-settings-item-link">/plugins/servlet/yaccHook/config</link>
+    </web-item>
 
     <!-- Global pre-receive hook module definitions -->
     <servlet key="yaccHook-config-servlet" name="YaccHook Configuration Servlet"

--- a/src/main/resources/static/serverside-config.soy
+++ b/src/main/resources/static/serverside-config.soy
@@ -11,33 +11,51 @@
         <title>Yet Another Commit Checker</title>
     </head>
     <body>
-	{call aui.group.group}
-	{param content}
-        {call widget.aui.form.form}
-	        {param action: '' /}
-	        {param content}
-		        <h2>Yet Another Commit Checker default configuration. Repository hook configuration wins.</h2>
-		        {call .formContents}
-	        		{param config: $config /}
-	        		{param errors: $errors /}
-			{/call}
-                                {call widget.aui.form.buttons}
-                                    {param content}
-                                        {call widget.aui.form.submit}
-                                            {param id: 'submit' /}
-                                            {param isPrimary: true /}
-                                            {param accessKey: 's' /}
-                                            {param label: 'Save' /}
-                                        {/call}
-                                        {call widget.aui.form.cancelButton}
-                                            {param href: nav_admin() /}
-                                        {/call}
-                                    {/param}
+        {call aui.group.group}
+            {param content}
+                {call widget.aui.form.form}
+                    {param action: '' /}
+                    {param content}
+                    <h2>Yet Another Commit Checker JIRA configuration.</h2>
+                        {call aui.form.checkboxField}
+                            {param legendContent: 'Enable override JIRA user' /}
+                            {param fields: [[
+                            'id' : 'overrideJiraUserEnabled',
+                            'labelText': 'Enabled',
+                            'isChecked' : $config['overrideJiraUserEnabled']
+                            ]] /}
+                            {param descriptionText: 'Impersonate a specific user when getting requests from JIRA.' /}
+                        {/call}
+
+                        {call aui.form.textField}
+                            {param id: 'overrideJiraUser' /}
+                            {param labelContent: 'Overriden user name' /}
+                            {param value:$config ? $config['overrideJiraUser'] : null /}
+                            {param descriptionText: 'Impersonating user name.' /}
+                            {param errorTexts: $errors ? $errors['overrideJiraUser'] : null /}
+                        {/call}
+                    <h2>Yet Another Commit Checker default configuration. Repository hook configuration wins.</h2>
+                        {call .formContents}
+                            {param config: $config /}
+                            {param errors: $errors /}
+                        {/call}
+                        {call widget.aui.form.buttons}
+                            {param content}
+                                {call widget.aui.form.submit}
+                                    {param id: 'submit' /}
+                                    {param isPrimary: true /}
+                                    {param accessKey: 's' /}
+                                    {param label: 'Save' /}
                                 {/call}
-		{/param}
-	{/call}
-	{/param}
-	{/call}
+                                {call widget.aui.form.cancelButton}
+                                    {param href: nav_admin() /}
+                                {/call}
+                            {/param}
+                        {/call}
+                    {/param}
+                {/call}
+            {/param}
+        {/call}
     </body>
 </html>
 {/template}

--- a/src/main/resources/yacc.properties
+++ b/src/main/resources/yacc.properties
@@ -1,2 +1,4 @@
 #put any key/value pairs here
-my.plugin.name=MyPlugin
+yacc.settings.item.name=YACC global settings
+yacc.settings.item.description=YACC global settings
+yacc-settings-item.label=YACC Settings

--- a/src/test/java/it/com/isroot/stash/plugin/SettingsTest.java
+++ b/src/test/java/it/com/isroot/stash/plugin/SettingsTest.java
@@ -51,17 +51,21 @@ public class SettingsTest {
                 .loginAsSysAdmin(YaccGlobalSettingsPage.class);
 
         verifyDefaults(globalSettings);
+        verifyDefaultGlobalSettings(globalSettings);
 
         setInvalidValues(globalSettings);
+        setInvalidGlobalValues(globalSettings);
         globalSettings.clickSubmit();
-        verifyValidationErrors(globalSettings);
+        verifyGlobalValidationErrors(globalSettings);
 
         setValues(globalSettings);
+        setGlobalValues(globalSettings);
         globalSettings.clickSubmit();
 
         globalSettings = STASH.visit(YaccGlobalSettingsPage.class);
 
         verifyValues(globalSettings);
+        verifyGlobalValues(globalSettings);
     }
 
     @Test
@@ -85,6 +89,11 @@ public class SettingsTest {
         verifyValues(repoSettingsPage);
     }
 
+    private void verifyDefaultGlobalSettings(YaccGlobalSettingsPage yaccGlobalSettingsPage) {
+        yaccGlobalSettingsPage.verifyOverrideJiraUserEnabled(false)
+            .verifyOverrideJiraUserText("");
+    }
+
     private void verifyDefaults(YaccSettingsCommon yaccSettingsCommon) {
         yaccSettingsCommon.verifyRequireMatchingAuthorName(false)
                 .verifyRequireMatchingAuthorEmail(false)
@@ -104,6 +113,10 @@ public class SettingsTest {
                 .verifyExcludeMergeCommits(false);
     }
 
+    private void setInvalidGlobalValues(YaccGlobalSettingsPage yaccGlobalSettingsPage) {
+        yaccGlobalSettingsPage.setOverrideJiraUserText("nonexistantuser");
+    }
+
     private void setInvalidValues(YaccSettingsCommon yaccSettingsCommon) {
         yaccSettingsCommon.setCommitMessageRegex("(invalid regex")
                 .setExcludeByRegex("(invalid regex")
@@ -114,6 +127,11 @@ public class SettingsTest {
     private void verifyValidationErrors(YaccSettingsCommon yaccSettingsCommon) {
         assertThat(yaccSettingsCommon.getFieldIdsWithErrors())
                 .containsOnly("commitMessageRegex", "excludeByRegex", "excludeBranchRegex", "committerEmailRegex");
+    }
+
+    private void verifyGlobalValidationErrors(YaccSettingsCommon yaccSettingsCommon) {
+        assertThat(yaccSettingsCommon.getFieldIdsWithErrors())
+                .containsOnly("overrideJiraUser", "commitMessageRegex", "excludeByRegex", "excludeBranchRegex", "committerEmailRegex");
     }
 
     private void setValues(YaccSettingsCommon yaccSettingsCommon) {
@@ -136,6 +154,11 @@ public class SettingsTest {
                 .clickExcludeServiceUserCommits();
     }
 
+    private void setGlobalValues(YaccGlobalSettingsPage yaccGlobalSettingsPage) {
+        yaccGlobalSettingsPage.clickOverrideJiraUserEnabled()
+            .setOverrideJiraUserText("admin");
+    }
+
     private void verifyValues(YaccSettingsCommon yaccSettingsCommon) {
         yaccSettingsCommon.verifyRequireMatchingAuthorEmail(true)
                 .verifyRequireMatchingAuthorName(true)
@@ -154,5 +177,10 @@ public class SettingsTest {
                 .verifyExcludeByRegex(".*")
                 .verifyExcludeBranchRegex(".*")
                 .verifyExcludeMergeCommits(true);
+    }
+
+    private void verifyGlobalValues(YaccGlobalSettingsPage yaccGlobalSettingsPage) {
+        yaccGlobalSettingsPage.verifyOverrideJiraUserEnabled(true)
+            .verifyOverrideJiraUserText("admin");
     }
 }

--- a/src/test/java/it/com/isroot/stash/plugin/pageobjects/YaccGlobalSettingsPage.java
+++ b/src/test/java/it/com/isroot/stash/plugin/pageobjects/YaccGlobalSettingsPage.java
@@ -3,6 +3,8 @@ package it.com.isroot.stash.plugin.pageobjects;
 import com.atlassian.pageobjects.elements.ElementBy;
 import com.atlassian.pageobjects.elements.PageElement;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Sean Ford
  * @since 2015-08-31
@@ -10,6 +12,12 @@ import com.atlassian.pageobjects.elements.PageElement;
 public class YaccGlobalSettingsPage extends YaccSettingsCommon {
     @ElementBy(id = "submit")
     private PageElement submit;
+
+    @ElementBy(id = "overrideJiraUserEnabled")
+    private PageElement overrideJiraUserEnabledCheckbox;
+
+    @ElementBy(id = "overrideJiraUser")
+    private PageElement overrideJiraUserText;
 
     @Override
     public String getUrl() {
@@ -19,6 +27,27 @@ public class YaccGlobalSettingsPage extends YaccSettingsCommon {
     public YaccSettingsCommon clickSubmit() {
         submit.click();
         waitABitForPageLoad();
+        return this;
+    }
+
+    public YaccGlobalSettingsPage clickOverrideJiraUserEnabled() {
+        overrideJiraUserEnabledCheckbox.click();
+        return this;
+    }
+
+    public YaccGlobalSettingsPage verifyOverrideJiraUserEnabled(boolean isSelected) {
+        assertThat(overrideJiraUserEnabledCheckbox.isSelected()).isEqualTo(isSelected);
+        return this;
+    }
+
+    public YaccGlobalSettingsPage setOverrideJiraUserText(String regex) {
+        overrideJiraUserText.clear();
+        overrideJiraUserText.type(regex);
+        return this;
+    }
+
+    public YaccGlobalSettingsPage verifyOverrideJiraUserText(String regex) {
+        assertThat(overrideJiraUserText.getValue()).isEqualTo(regex);
         return this;
     }
 

--- a/src/test/java/it/com/isroot/stash/plugin/pageobjects/YaccRepoSettingsPage.java
+++ b/src/test/java/it/com/isroot/stash/plugin/pageobjects/YaccRepoSettingsPage.java
@@ -47,7 +47,7 @@ public class YaccRepoSettingsPage extends YaccSettingsCommon {
 
         log.info("enabling yacc");
 
-        inheritToggle.toggle();
+        inheritToggle.select();
         enabledOption.click();
 
         return this;
@@ -62,7 +62,7 @@ public class YaccRepoSettingsPage extends YaccSettingsCommon {
     public YaccRepoSettingsPage clickDisable() {
         log.info("disabling yacc");
 
-        inheritToggle.toggle();
+        inheritToggle.select();
         disabledOption.click();
 
         return this;

--- a/src/test/java/ut/com/isroot/stash/plugin/ConfigValidatorTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/ConfigValidatorTest.java
@@ -3,6 +3,7 @@ package ut.com.isroot.stash.plugin;
 import com.atlassian.bitbucket.scope.Scope;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.setting.SettingsValidationErrors;
+import com.atlassian.bitbucket.user.UserService;
 import com.isroot.stash.plugin.ConfigValidator;
 import com.isroot.stash.plugin.JiraService;
 import org.junit.Before;
@@ -27,6 +28,7 @@ public class ConfigValidatorTest {
     @Mock private Settings settings;
     @Mock private SettingsValidationErrors settingsValidationErrors;
     @Mock private Scope scope;
+    @Mock private UserService userService;
 
     private ConfigValidator configValidator;
 
@@ -35,7 +37,7 @@ public class ConfigValidatorTest {
         MockitoAnnotations.initMocks(this);
         System.setProperty("line.separator", "\n");
 
-        configValidator = new ConfigValidator(jiraService);
+        configValidator = new ConfigValidator(jiraService, userService);
     }
 
     @Test

--- a/src/test/java/ut/com/isroot/stash/plugin/YaccConfigServletTest.java
+++ b/src/test/java/ut/com/isroot/stash/plugin/YaccConfigServletTest.java
@@ -3,6 +3,7 @@ package ut.com.isroot.stash.plugin;
 import com.atlassian.bitbucket.hook.repository.RepositoryHookService;
 import com.atlassian.bitbucket.nav.NavBuilder;
 import com.atlassian.bitbucket.setting.Settings;
+import com.atlassian.bitbucket.user.UserService;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.testresources.pluginsettings.MockPluginSettings;
@@ -39,6 +40,7 @@ public class YaccConfigServletTest {
     @Mock private NavBuilder navBuilder;
     @Mock private NavBuilder.Addons addons;
     @Mock private Settings settings;
+    @Mock private UserService userService;
 
     @Mock private HttpServletRequest request;
     @Mock private HttpServletResponse response;
@@ -60,7 +62,7 @@ public class YaccConfigServletTest {
         when(addons.buildRelative()).thenReturn("/yaccHook/config");
 
         yaccConfigServlet = new YaccConfigServlet(soyTemplateRenderer,
-                pluginSettingsFactory, jiraService, repositoryHookService, navBuilder);
+                pluginSettingsFactory, jiraService, repositoryHookService, navBuilder, userService);
     }
 
     @Test


### PR DESCRIPTION
Hi,
I propose the following changes for YACC:
1. Enable YACC checks for Bitbucket web editor.
2. Use global settings to configure a user override for JIRA requests. This allows to impersonate admin configured user account (technical account) that will be used to check if issues exist. Sometimes a team uses some automation scripts to commit changes, and that user account doesn't have permissions in JIRA to browse the issues, so to allow this we can impersonate a specific technical account that has this permission. This also allows to commit changes with SSH keys only.